### PR TITLE
修飾キーの入力発行順序をリリース優先に変更

### DIFF
--- a/keyhac_keymap.py
+++ b/keyhac_keymap.py
@@ -1337,6 +1337,10 @@ class Keymap(ckit.Window):
                 self.input_seq.append( pyauto.KeyDown(vk_mod[0]) )
                 self.virtual_modifier |= vk_mod[1]
 
+        # Win と Alt の単体押しをキャンセル
+        if cancel_oneshot_win_alt:
+            self.input_seq.append( pyauto.Key( VK_LCONTROL ) )
+
     def setInput_FromString( self, s ):
 
         s = s.upper()


### PR DESCRIPTION
## Description

- 修飾キーの入力発行順序をリリース優先に変更しました。
- リリース処理の前に、Win/Alt単体押しのキャンセル処理を実行するので、 `Win` や `Alt` でスタートメニューやメニューバーにフォーカスが移ることはありません。

## Test

以下の動作を確認しました。

- `Win-Left` を `Ctrl+Left` に変換したときに、スタートメニューにフォーカスが移らないこと
- `Alt-Left` を `Win+Left` に変換したときに、スタートメニュー、メニューバーにフォーカスが移らないこと
- `Win-Shift-Left` を `Win-Ctrl-Alt-Left` に変換したときに、[Officeが開く](https://forest.watch.impress.co.jp/docs/serial/yajiuma/1369950.html)ことがないこと

## Related issues

- #50