### PR TITLE
Windows portable mode: config.py next to Keyhac.exe

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,8 @@
 # Configuration
 
-Keyhac is configured with one Python file: `~/.keyhac/config.py`. On first run it is
+Keyhac is configured with one Python file: `~/.keyhac/config.py` (or, in Windows
+[portable mode](installation.md#portable-mode-windows), the `config.py` sitting next
+to `Keyhac.exe`). On first run it is
 created from a fully commented template — the template
 ([keyhac/_config.py](../keyhac/_config.py) in the source tree) is a working example of
 everything on this page, and a good file to keep open while reading.

--- a/doc/dev/design-notes.md
+++ b/doc/dev/design-notes.md
@@ -4,7 +4,7 @@ Per-feature design decisions and the subtle behaviors deliberately carried over 
 the predecessors (keyhac-win 1.83 / keyhac-mac 1.68 — the frozen feature references).
 Keyhac2 targets the **union** of both feature sets; the few remaining gaps are
 tracked as GitHub issues (migemo matching, cron/periodic API, themes/fonts, i18n,
-portable mode, rich clipboard formats).
+rich clipboard formats).
 
 ## Deliberate ports of subtle behaviors — do not "simplify" these
 
@@ -108,3 +108,51 @@ portable mode, rich clipboard formats).
   scrollWheel types join the tap mask on macOS (motion deliberately untapped —
   Python must not sit in the path of every pointer move). Own output is recognized
   via `dwExtraInfo` / event source and ignored.
+
+## Data directory and Windows portable mode
+
+`keyhac/core/paths.py` is the single place that decides where `config.py` and the
+state files beside it (`extensions/`, `clipboard.json`, `settings.json`) live.
+Three ways, first match winning — `main()` resolves once and hands explicit paths
+to `Keymap`, `ClipboardHistory` and `Settings`, so nothing downstream re-derives a
+default:
+
+1. `--config PATH` — state beside the named config. Existed before this module; a
+   sandboxed run must not touch the real `~/.keyhac`.
+2. **Portable mode (Windows)** — a `config.py` next to `Keyhac.exe` makes the
+   bundle directory the data directory. Straight port of keyhac-win 1.x
+   (`keyhac_main.py`: *"exeと同じ位置にある設定ファイルを優先する"*), including
+   the opt-in: the file's presence is the whole switch, deleting it reverts to
+   `~/.keyhac`. No macOS counterpart — an `.app` is signed and Gatekeeper
+   re-validates it, so writing state inside the bundle is not an option.
+3. `~/.keyhac` — the default.
+
+- **Bundle detection is by layout, not by name.** `bundle_dir()` calls it a bundle
+  when `<dir-of-sys.executable>\app\keyhac\` exists (what `windows_app/build.ps1`
+  step 4 assembles). Matching on `Keyhac.exe` instead would break a renamed
+  launcher, and — worse — matching on nothing at all would let a stray `config.py`
+  beside a venv's `python.exe` switch a source run (`python -m keyhac`) into
+  portable mode.
+- **A portable data directory can be read-only** (a write-protected stick, or an
+  install under Program Files whose `config.py` an admin placed). `Settings` and
+  `ClipboardHistory` already log-and-continue on `OSError`; `configure()`'s
+  `extensions/` creation now does too, so a read-only directory costs that
+  directory and not the config load.
+- **Not portable yet:** PuiKit stores the console window's frame under
+  `HKCU\Software\PuiKit\FrameAutosave` (`frame_autosave_name="KeyhacConsole"`), and
+  the Windows launcher writes `keyhac-error.log` to `~/.keyhac` on a bootstrap
+  crash — deliberately, since the bundle directory may be read-only. Both leave a
+  trace outside a portable install.
+
+### First-run migration from keyhac-win 1.x
+
+`keyhac/platform/win/migrate.py`. On Windows, on a first run only (no
+`~/.keyhac/config.py`, a `%APPDATA%\Keyhac\config.py` present), a `MessageBoxW`
+offers to copy the 1.x config across — the move
+[migration-from-keyhac-win.md](../migration-from-keyhac-win.md) already prescribes
+before translating. It is a prompt rather than a silent copy because the two APIs
+are not interchangeable: the copied file will not load until it is translated, and
+declining leaves the working stock template. Skipped in `--no-ui` runs (no message
+box) and in portable mode (which has a `config.py` by definition). A message box
+rather than a PuiKit dialog because this runs before the console window exists —
+the same fallback `instance.py`'s already-running notice uses.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -91,9 +91,31 @@ Everything lives under `~/.keyhac/` on both OSes:
 Running with `--config PATH` keeps `clipboard.json` and `settings.json` beside that
 config file instead — handy for a sandboxed or experimental setup.
 
+### Portable mode (Windows)
+
+Put a `config.py` next to `Keyhac.exe` and that directory becomes the data
+directory — config, clipboard history and settings all live beside the executable
+and nothing is written to your user profile. This is the same portable mode
+Keyhac 1.x had, and the same opt-in: the file's presence is the whole switch, so
+deleting it goes back to `~/.keyhac`.
+
+Use it for Keyhac on a USB stick, or to keep several independent setups side by
+side. Start from a copy of your existing `~/.keyhac/config.py`, or of
+[the template](../keyhac/_config.py).
+
+Two things still live outside a portable install: the console window's remembered
+position (`HKCU\Software\PuiKit\FrameAutosave`) and `keyhac-error.log`, written to
+`~/.keyhac` if Keyhac fails before its window opens. Neither affects your
+configuration.
+
+Portable mode is Windows-only — a macOS `.app` is a signed bundle that Gatekeeper
+re-validates, so Keyhac cannot write into it. Use `--config PATH` there.
+
 **Note for Keyhac-for-Windows (1.x) users**: the data directory moved from
-`%APPDATA%\Keyhac` to `~/.keyhac`. Your old `config.py` needs API migration anyway —
-see [migration-from-keyhac-win.md](migration-from-keyhac-win.md).
+`%APPDATA%\Keyhac` to `~/.keyhac`. On its first run Keyhac 2 spots a 1.x
+`config.py` there and offers to copy it across; it still needs an API migration
+pass afterwards — see
+[migration-from-keyhac-win.md](migration-from-keyhac-win.md).
 
 ## Privacy notes
 

--- a/doc/migration-from-keyhac-win.md
+++ b/doc/migration-from-keyhac-win.md
@@ -8,9 +8,18 @@ one-to-one, and key expressions are unchanged (the short modifier forms `C-`, `A
 
 The entry point is the same (`def configure(keymap):`), but the file's location moved:
 Keyhac 2 reads `~/.keyhac/config.py`, not `%APPDATA%\Keyhac\config.py`. Copy your
-config there before translating. Clipboard history and settings move with it
+config there before translating — on its first run Keyhac 2 finds the 1.x file and
+offers to do that copy for you. Clipboard history and settings move with it
 (`~/.keyhac/clipboard.json` / `settings.json`); the 1.x ini and its history are not
 imported.
+
+Until the translation pass is done the copied config will fail to load; the console
+window shows the error and every key passes through untouched, so nothing is stuck —
+delete the file to fall back to the stock template at any point.
+
+Portable mode came across too: a `config.py` next to `Keyhac.exe` still wins over the
+per-user directory, exactly as in 1.x. See
+[installation.md](installation.md#portable-mode-windows).
 
 ## Translation table
 

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -153,7 +153,15 @@ class Keymap:
 
             logger.info("Loading configuration script.")
 
-            os.makedirs(os.path.join(os.path.dirname(self._config_path), "extensions"), exist_ok=True)
+            extensions_dir = os.path.join(os.path.dirname(self._config_path), "extensions")
+            try:
+                os.makedirs(extensions_dir, exist_ok=True)
+            except OSError as e:
+                # A read-only data directory - a portable install on a
+                # write-protected stick, or one whose config.py an admin put
+                # beside Keyhac.exe under Program Files - costs the extensions
+                # directory, not the config load.
+                logger.warning(f"Could not create {extensions_dir}: {e}")
 
             try:
                 self.config = Config(self._config_path, self._template_path)

--- a/keyhac/core/paths.py
+++ b/keyhac/core/paths.py
@@ -1,0 +1,117 @@
+"""Where Keyhac keeps config.py and the state files that live beside it.
+
+One directory holds everything: ``config.py``, ``extensions/``,
+``clipboard.json``, ``settings.json``.  Three ways it is chosen, first match
+winning:
+
+1. **An explicit** ``--config PATH`` — the state files sit beside the named
+   config, so a sandboxed or experimental run cannot touch the real
+   ``~/.keyhac``.
+2. **Portable mode (Windows)** — a ``config.py`` sitting next to
+   ``Keyhac.exe`` makes the bundle's own directory the data directory.  This
+   is keyhac-win 1.x's portable mode, unchanged in spirit: Keyhac on a USB
+   stick carries its configuration and its clipboard history with it and
+   writes nothing into the user profile.  Dropping a ``config.py`` next to the
+   exe is the whole opt-in; deleting it reverts to ``~/.keyhac``.
+3. ``~/.keyhac`` — the default on both OSes.
+
+Portable mode has no macOS counterpart: an ``.app`` bundle is a signed,
+read-only artifact that Gatekeeper re-validates, so writing state inside it is
+not an option there.
+
+Path resolution only — no OS calls.  The Windows-only first-run migration
+offer that reads :func:`legacy_windows_data_dir` lives in
+``keyhac/platform/win/migrate.py``, since it needs a message box.
+"""
+
+import os
+import sys
+
+#: The configuration script's filename, in every mode.
+CONFIG_NAME = "config.py"
+
+#: Directory the Windows launcher assembles Keyhac's own code into, relative to
+#: the bundle root (windows_app/build.ps1 step 4; see launcher.c's layout map).
+#: Its presence is what identifies a bundle root — see :func:`bundle_dir`.
+_BUNDLE_APP_MARKER = os.path.join("app", "keyhac")
+
+#: keyhac-win 1.x's data directory, under %APPDATA%.
+_LEGACY_WIN_DIRNAME = "Keyhac"
+
+
+class Paths:
+    """The resolved config path and the directory holding it."""
+
+    def __init__(self, config_path: str, portable: bool = False):
+        self.config_path = os.path.abspath(config_path)
+        self.data_dir = os.path.dirname(self.config_path)
+        self.portable = portable
+
+    def state_file(self, name: str) -> str:
+        """A state file (clipboard.json, settings.json) beside the config."""
+        return os.path.join(self.data_dir, name)
+
+    def __repr__(self) -> str:
+        return (f"Paths(config_path={self.config_path!r}, "
+                f"portable={self.portable!r})")
+
+
+def default_data_dir() -> str:
+    """``~/.keyhac`` — where Keyhac 2 keeps everything unless told otherwise."""
+    return os.path.expanduser(os.path.join("~", ".keyhac"))
+
+
+def bundle_dir() -> str | None:
+    """The directory holding ``Keyhac.exe`` when running from the Windows
+    bundle, else None.
+
+    Identified by the bundle's *layout* (``<root>\\app\\keyhac\\``) rather than
+    by the executable's name: a user who renamed ``Keyhac.exe`` still gets
+    portable mode, and running from source — where ``sys.executable`` is a
+    plain (possibly venv) ``python.exe`` — never mistakes the interpreter's
+    directory for a bundle root.
+    """
+    if sys.platform != "win32":
+        return None
+    executable = getattr(sys, "executable", "") or ""
+    if not executable:
+        return None
+    root = os.path.dirname(os.path.abspath(executable))
+    if os.path.isdir(os.path.join(root, _BUNDLE_APP_MARKER)):
+        return root
+    return None
+
+
+def portable_dir() -> str | None:
+    """The bundle directory when it holds a ``config.py`` (portable mode is
+    on), else None.  Presence of that file is the entire opt-in."""
+    root = bundle_dir()
+    if root is None:
+        return None
+    if os.path.isfile(os.path.join(root, CONFIG_NAME)):
+        return root
+    return None
+
+
+def legacy_windows_data_dir() -> str | None:
+    """``%APPDATA%\\Keyhac`` — keyhac-win 1.x's data directory — when it
+    exists, else None.  Keyhac 2 never reads from it; it is only the source
+    offered on a first run (see ``platform/win/migrate.py``)."""
+    if sys.platform != "win32":
+        return None
+    appdata = os.environ.get("APPDATA")
+    if not appdata:
+        return None
+    legacy = os.path.join(appdata, _LEGACY_WIN_DIRNAME)
+    return legacy if os.path.isdir(legacy) else None
+
+
+def resolve(config_arg: str | None = None) -> Paths:
+    """Decide where this run reads and writes.  ``config_arg`` is ``--config``
+    as given on the command line (None when it was not)."""
+    if config_arg:
+        return Paths(config_arg)
+    portable = portable_dir()
+    if portable is not None:
+        return Paths(os.path.join(portable, CONFIG_NAME), portable=True)
+    return Paths(os.path.join(default_data_dir(), CONFIG_NAME))

--- a/keyhac/main.py
+++ b/keyhac/main.py
@@ -13,7 +13,7 @@ import argparse
 import signal
 import sys
 
-from keyhac.core import log
+from keyhac.core import log, paths
 from keyhac.core.keymap import Keymap
 
 logger = log.getLogger("Main")
@@ -24,8 +24,9 @@ def main() -> int:
     parser.add_argument("-d", "--debug", action="store_true",
                         help="enable debug logging (key events, dispatch)")
     parser.add_argument("-c", "--config", metavar="PATH", default=None,
-                        help="config file path (default: ~/.keyhac/config.py; "
-                             "created from the template if missing)")
+                        help="config file path (default: ~/.keyhac/config.py, "
+                             "or the Keyhac.exe directory in Windows portable "
+                             "mode; created from the template if missing)")
     parser.add_argument("--no-ui", action="store_true",
                         help="run without the console window (headless, logs to stderr)")
     args = parser.parse_args()
@@ -67,9 +68,23 @@ def main() -> int:
                 "System Settings > Privacy & Security > Accessibility, then restart Keyhac.")
             return 1
 
+    # Where config.py and the state files beside it live: --config, else
+    # Windows portable mode (a config.py next to Keyhac.exe), else ~/.keyhac.
+    app_paths = paths.resolve(args.config)
+    if app_paths.portable:
+        logger.info(f"Portable mode: using {app_paths.data_dir}")
+    elif platform_name == "windows" and not args.no_ui and not args.config:
+        # First run on a machine upgrading from Keyhac 1.x: offer to bring the
+        # old %APPDATA%\Keyhac config across before anything reads (or
+        # template-creates) the new one.  Needs a message box, so not in
+        # --no-ui runs; and an explicit --config asked for a specific setup,
+        # which a sandbox expects to start from the template.
+        platform_module.offer_config_migration(app_paths.config_path)
+
     hook, focus_provider, native_loop = platform_module.create_platform()
 
-    keymap = Keymap(hook, focus_provider, platform_name, config_path=args.config)
+    keymap = Keymap(hook, focus_provider, platform_name,
+                    config_path=app_paths.config_path)
 
     # Clipboard history + app control (platform services above the hook)
     from keyhac.core.clipboard_history import ClipboardHistory
@@ -87,13 +102,11 @@ def main() -> int:
         clipboard_provider = WinClipboardProvider()
         keymap.app_control = WinAppControl()
         keymap.window_provider = WinWindowProvider()
-    # With an explicit --config, keep the app-state files beside it (sandbox
-    # testing must not touch the real ~/.keyhac/clipboard.json etc.).
-    import os
-    state_dir = (os.path.dirname(os.path.abspath(args.config))
-                 if args.config else None)
-    history_path = os.path.join(state_dir, "clipboard.json") if state_dir else None
-    keymap._clipboard_history = ClipboardHistory(clipboard_provider, history_path)
+    # The state files always sit beside the config, however it resolved: a
+    # --config sandbox must not touch the real ~/.keyhac/clipboard.json, and a
+    # portable install keeps its history on the stick with its config.
+    keymap._clipboard_history = ClipboardHistory(
+        clipboard_provider, app_paths.state_file("clipboard.json"))
 
     keymap.configure()
 
@@ -102,9 +115,8 @@ def main() -> int:
                              clipboard_provider)
 
     from keyhac.core.settings import Settings
-    settings_path = os.path.join(state_dir, "settings.json") if state_dir else None
     return _run_with_console(keymap, hook, platform_name, clipboard_provider,
-                             Settings(settings_path))
+                             Settings(app_paths.state_file("settings.json")))
 
 
 def _run_with_console(keymap, hook, platform_name: str, clipboard_provider,

--- a/keyhac/platform/win/__init__.py
+++ b/keyhac/platform/win/__init__.py
@@ -22,3 +22,8 @@ def acquire_instance_lock():
 def notify_already_running():
     from keyhac.platform.win.instance import notify_already_running
     notify_already_running()
+
+
+def offer_config_migration(target_config_path):
+    from keyhac.platform.win.migrate import offer_config_migration
+    return offer_config_migration(target_config_path)

--- a/keyhac/platform/win/migrate.py
+++ b/keyhac/platform/win/migrate.py
@@ -1,0 +1,101 @@
+"""First-run offer to bring a Keyhac-for-Windows (1.x) config.py forward.
+
+1.x kept its configuration in ``%APPDATA%\\Keyhac``; Keyhac 2 reads
+``~/.keyhac/config.py`` (see ``keyhac/core/paths.py``).  An upgrading user who
+just installs Keyhac 2 therefore meets the stock template and their years-old
+config sitting somewhere they have no reason to look.
+
+So on a first run only - no ``~/.keyhac/config.py`` yet, a
+``%APPDATA%\\Keyhac\\config.py`` there - Keyhac offers to copy it across.  The
+copy is deliberately *not* silent, because the two configs are not
+interchangeable: 1.x's camelCase API has no compatibility shim in Keyhac 2, so
+the copied file needs a translation pass before it loads (the console shows
+the error until it gets one, and the previous keymap - none, on a first run -
+stays active).  ``doc/migration-from-keyhac-win.md`` prescribes exactly this
+move, "copy your config there before translating"; the dialog names it and
+declining leaves the stock template in place.
+
+A message box, not a PuiKit dialog: this runs before the console window
+exists, and the same MessageBoxW fallback already serves the single-instance
+notice (``instance.py``).
+"""
+
+import ctypes
+import os
+import shutil
+import sys
+
+from keyhac.core import log, paths
+
+logger = log.getLogger("Migrate")
+
+if sys.platform == "win32":
+    from ctypes import wintypes
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+
+    # Mandatory on 64-bit: the default c_int restype truncates HWND/HANDLE.
+    user32.MessageBoxW.argtypes = (wintypes.HWND, wintypes.LPCWSTR,
+                                   wintypes.LPCWSTR, wintypes.UINT)
+    user32.MessageBoxW.restype = ctypes.c_int
+
+    MB_YESNO = 0x04
+    MB_ICONQUESTION = 0x20
+    IDYES = 6
+
+_PROMPT = """\
+A Keyhac 1.x configuration was found at:
+
+    {source}
+
+Keyhac 2 reads {target} instead.
+
+Copy it there now?
+
+Note: Keyhac 2 uses a different (snake_case) configuration API, so the copied
+file will need a translation pass before it loads - see
+doc/migration-from-keyhac-win.md. Choosing No keeps the stock template, which
+works as-is."""
+
+
+def offer_config_migration(target_config_path: str) -> bool:
+    """Offer to copy a 1.x ``config.py`` to ``target_config_path``.  Returns
+    True if one was copied.
+
+    A no-op unless this really is a first run with something to migrate: the
+    target must not exist, and ``%APPDATA%\\Keyhac\\config.py`` must.  Any
+    failure is logged and swallowed - a migration that cannot happen must not
+    stop Keyhac from starting with the stock template.
+    """
+    if sys.platform != "win32":
+        return False
+    if os.path.exists(target_config_path):
+        return False
+
+    legacy_dir = paths.legacy_windows_data_dir()
+    if legacy_dir is None:
+        return False
+    source = os.path.join(legacy_dir, paths.CONFIG_NAME)
+    if not os.path.isfile(source):
+        return False
+
+    answer = user32.MessageBoxW(
+        None,
+        _PROMPT.format(source=source, target=target_config_path),
+        "Keyhac - import your Keyhac 1.x configuration?",
+        MB_YESNO | MB_ICONQUESTION)
+    if answer != IDYES:
+        logger.info(f"Keyhac 1.x config at {source} left in place "
+                    "(starting from the template).")
+        return False
+
+    try:
+        os.makedirs(os.path.dirname(target_config_path), exist_ok=True)
+        shutil.copyfile(source, target_config_path)
+    except OSError as e:
+        logger.error(f"Could not copy {source} to {target_config_path}: {e}")
+        return False
+
+    logger.info(f"Copied the Keyhac 1.x config from {source}. It uses the 1.x "
+                "API and needs migrating - see doc/migration-from-keyhac-win.md.")
+    return True

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,219 @@
+"""keyhac.core.paths - config/data directory resolution, incl. Windows
+portable mode (a config.py next to Keyhac.exe)."""
+
+import os
+import sys
+
+import pytest
+
+from keyhac.core import paths
+
+
+def _make_bundle(root, with_config=True):
+    """A directory shaped like the Windows bundle windows_app/build.ps1
+    assembles: Keyhac.exe at the root, the app package under app\\keyhac."""
+    (root / "app" / "keyhac").mkdir(parents=True)
+    exe = root / "Keyhac.exe"
+    exe.write_text("")
+    if with_config:
+        (root / "config.py").write_text("def configure(keymap):\n    pass\n")
+    return exe
+
+
+class TestDefaults:
+
+    def test_default_is_the_home_directory(self, monkeypatch):
+        monkeypatch.setattr(paths, "portable_dir", lambda: None)
+        resolved = paths.resolve()
+        assert resolved.config_path == os.path.join(paths.default_data_dir(), "config.py")
+        assert resolved.data_dir == paths.default_data_dir()
+        assert resolved.portable is False
+
+    def test_explicit_config_puts_state_beside_it(self, tmp_path, monkeypatch):
+        # An explicit --config wins over portable mode, so a sandboxed run
+        # stays sandboxed even when launched from a portable install.
+        monkeypatch.setattr(paths, "portable_dir", lambda: str(tmp_path / "bundle"))
+        target = tmp_path / "sandbox" / "config.py"
+        resolved = paths.resolve(str(target))
+        assert resolved.config_path == str(target)
+        assert resolved.data_dir == str(tmp_path / "sandbox")
+        assert resolved.portable is False
+
+    def test_state_files_sit_beside_the_config(self, tmp_path):
+        resolved = paths.resolve(str(tmp_path / "config.py"))
+        assert resolved.state_file("clipboard.json") == str(tmp_path / "clipboard.json")
+        assert resolved.state_file("settings.json") == str(tmp_path / "settings.json")
+
+    def test_relative_config_is_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        resolved = paths.resolve("config.py")
+        assert os.path.isabs(resolved.config_path)
+        assert resolved.config_path == str(tmp_path / "config.py")
+
+
+class TestBundleDetection:
+    """bundle_dir() keys on the bundle's layout, not on the exe's name."""
+
+    def test_none_off_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert paths.bundle_dir() is None
+        assert paths.portable_dir() is None
+        assert paths.legacy_windows_data_dir() is None
+
+    def test_recognizes_the_bundle_layout(self, tmp_path, monkeypatch):
+        exe = _make_bundle(tmp_path)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "executable", str(exe))
+        assert paths.bundle_dir() == str(tmp_path)
+
+    def test_a_renamed_launcher_still_finds_its_bundle(self, tmp_path, monkeypatch):
+        _make_bundle(tmp_path)
+        renamed = tmp_path / "MyKeys.exe"
+        renamed.write_text("")
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "executable", str(renamed))
+        assert paths.bundle_dir() == str(tmp_path)
+
+    def test_a_plain_interpreter_is_not_a_bundle(self, tmp_path, monkeypatch):
+        # `python -m keyhac` from a checkout: sys.executable is a (possibly
+        # venv) python.exe whose directory has no app\keyhac in it, so a
+        # stray config.py sitting next to it must not turn portable mode on.
+        scripts = tmp_path / "Scripts"
+        scripts.mkdir()
+        (scripts / "python.exe").write_text("")
+        (scripts / "config.py").write_text("")
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "executable", str(scripts / "python.exe"))
+        assert paths.bundle_dir() is None
+        assert paths.portable_dir() is None
+
+
+class TestPortableMode:
+
+    def test_config_next_to_the_exe_turns_it_on(self, tmp_path, monkeypatch):
+        exe = _make_bundle(tmp_path)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "executable", str(exe))
+
+        resolved = paths.resolve()
+        assert resolved.portable is True
+        assert resolved.data_dir == str(tmp_path)
+        assert resolved.config_path == str(tmp_path / "config.py")
+        # State follows the config, so nothing lands in the user profile.
+        assert resolved.state_file("clipboard.json") == str(tmp_path / "clipboard.json")
+
+    def test_a_bundle_without_a_config_is_not_portable(self, tmp_path, monkeypatch):
+        # The whole opt-in is dropping config.py next to the exe; an ordinary
+        # installed Keyhac has none there and keeps using ~/.keyhac.
+        exe = _make_bundle(tmp_path, with_config=False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "executable", str(exe))
+        assert paths.portable_dir() is None
+        assert paths.resolve().portable is False
+
+    def test_a_config_directory_does_not_count(self, tmp_path, monkeypatch):
+        exe = _make_bundle(tmp_path, with_config=False)
+        (tmp_path / "config.py").mkdir()
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "executable", str(exe))
+        assert paths.portable_dir() is None
+
+
+class TestLegacyWindowsDataDir:
+
+    def test_found_when_it_exists(self, tmp_path, monkeypatch):
+        appdata = tmp_path / "AppData" / "Roaming"
+        (appdata / "Keyhac").mkdir(parents=True)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("APPDATA", str(appdata))
+        assert paths.legacy_windows_data_dir() == str(appdata / "Keyhac")
+
+    def test_none_when_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("APPDATA", str(tmp_path))
+        assert paths.legacy_windows_data_dir() is None
+
+    def test_none_without_appdata(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("APPDATA", raising=False)
+        assert paths.legacy_windows_data_dir() is None
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only migration offer")
+class TestConfigMigration:
+    """platform/win/migrate.py - the first-run offer to copy a 1.x config.
+    The message box is stubbed; what is under test is when it is asked at all
+    and what the answer does."""
+
+    @pytest.fixture
+    def migrate(self):
+        from keyhac.platform.win import migrate
+        return migrate
+
+    def _stub_answer(self, migrate, monkeypatch, answer):
+        asked = []
+
+        class FakeUser32:
+            def MessageBoxW(self, hwnd, text, caption, flags):
+                asked.append(text)
+                return answer
+
+        monkeypatch.setattr(migrate, "user32", FakeUser32())
+        return asked
+
+    def test_copies_on_yes(self, tmp_path, monkeypatch, migrate):
+        legacy = tmp_path / "appdata" / "Keyhac"
+        legacy.mkdir(parents=True)
+        (legacy / "config.py").write_text("# 1.x config\n")
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+        asked = self._stub_answer(migrate, monkeypatch, migrate.IDYES)
+
+        target = tmp_path / "home" / ".keyhac" / "config.py"
+        assert migrate.offer_config_migration(str(target)) is True
+        assert target.read_text() == "# 1.x config\n"
+        assert len(asked) == 1
+        # The prompt has to say the copy needs translating, or a user says yes
+        # and gets a config that will not load without knowing why.
+        assert "migration-from-keyhac-win.md" in asked[0]
+
+    def test_declining_leaves_the_template(self, tmp_path, monkeypatch, migrate):
+        legacy = tmp_path / "appdata" / "Keyhac"
+        legacy.mkdir(parents=True)
+        (legacy / "config.py").write_text("# 1.x config\n")
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+        self._stub_answer(migrate, monkeypatch, 7)  # IDNO
+
+        target = tmp_path / "home" / ".keyhac" / "config.py"
+        assert migrate.offer_config_migration(str(target)) is False
+        assert not target.exists()
+
+    def test_not_offered_when_the_target_exists(self, tmp_path, monkeypatch, migrate):
+        legacy = tmp_path / "appdata" / "Keyhac"
+        legacy.mkdir(parents=True)
+        (legacy / "config.py").write_text("# 1.x config\n")
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+        asked = self._stub_answer(migrate, monkeypatch, migrate.IDYES)
+
+        target = tmp_path / "config.py"
+        target.write_text("# keyhac 2 config\n")
+        assert migrate.offer_config_migration(str(target)) is False
+        assert asked == []                            # not a first run
+        assert target.read_text() == "# keyhac 2 config\n"
+
+    def test_not_offered_without_a_legacy_config(self, tmp_path, monkeypatch, migrate):
+        (tmp_path / "appdata" / "Keyhac").mkdir(parents=True)  # dir, no config.py
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+        asked = self._stub_answer(migrate, monkeypatch, migrate.IDYES)
+        assert migrate.offer_config_migration(str(tmp_path / "config.py")) is False
+        assert asked == []
+
+    def test_an_unwritable_target_is_survivable(self, tmp_path, monkeypatch, migrate):
+        legacy = tmp_path / "appdata" / "Keyhac"
+        legacy.mkdir(parents=True)
+        (legacy / "config.py").write_text("# 1.x config\n")
+        monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+        self._stub_answer(migrate, monkeypatch, migrate.IDYES)
+        # Target's parent is a *file*: makedirs raises, and startup must go on.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("")
+        assert migrate.offer_config_migration(str(blocker / "config.py")) is False


### PR DESCRIPTION
keyhac-win 1.x preferred a config.py sitting beside the exe over %APPDATA%\Keyhac ("exeと同じ位置にある設定ファイルを優先する"); Keyhac 2 only ever knew ~/.keyhac and the --config override, so a Keyhac on a USB stick had nowhere to keep its configuration.

keyhac/core/paths.py now owns the decision, with three ways and the first match winning: --config, then a config.py next to Keyhac.exe (portable), then ~/.keyhac. main() resolves once and hands explicit paths to Keymap, ClipboardHistory and Settings, so the state files follow the config in every mode instead of each defaulting to ~/.keyhac on its own. extensions/ follows too, since it is derived from the config's directory.

The bundle is recognized by its layout - <dir of sys.executable>\app\keyhac, what windows_app/build.ps1 assembles - rather than by the executable's name. A renamed launcher still finds its bundle, and a source run (`python -m keyhac`, where sys.executable is a venv python.exe) can never be turned portable by a stray config.py sitting beside the interpreter. Portable mode has no macOS counterpart: an .app is signed and Gatekeeper re-validates it, so writing state inside the bundle is not an option.

A portable data directory can be read-only (a write-protected stick, or an install under Program Files whose config.py an admin placed). Settings and ClipboardHistory already log-and-continue on OSError; configure()'s extensions/ creation now does too, rather than aborting the config load.

Also the first-run migration offer the issue asked for: on Windows, with no ~/.keyhac/config.py and a %APPDATA%\Keyhac\config.py present, a message box offers to copy it across - the move doc/migration-from-keyhac-win.md already prescribes before translating. A prompt and not a silent copy, because the 1.x camelCase API has no shim here: the copied file will not load until it is translated, and declining leaves the working stock template. Skipped in --no-ui runs and in portable mode.

Closes #13.