### PR TITLE
Mark the AI integration experimental, and say what that buys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ and the macOS bundle is signed/notarized and verified end-to-end. The live
 verification record — including which passes caught which real bugs — is in
 [doc/dev/testing.md](doc/dev/testing.md).
 
+**AI integration ships as experimental** — the MCP endpoint (`keyhac/mcp/`), the
+action API (`keymap.ui`, `UINode`) and the authoring skill. It is off unless a
+config calls `enable_mcp_server()`, and it is the one part of the public surface
+**not** covered by the usual additive-only expectation: `UINode`'s element
+identity and handle lifetime are still open ([doc/dev/ai-integration.md](doc/dev/ai-integration.md)
+§11), and settling them may break actions. Do not treat that surface as frozen,
+and do not extend the experimental marker to anything else.
+
 What remains is tracked in the GitHub issues: the deferred features (themes/fonts,
 i18n, migemo, rich clipboard formats, macOS ISO layout, balloon help UI). The
 genuinely-interactive verification passes are through (issue #10, closed), but

--- a/doc/action_api.md
+++ b/doc/action_api.md
@@ -10,6 +10,14 @@ Generated from the docstrings. For how to *write* an action, the authoring
 skill in `keyhac/skills/action-authoring/` is the procedural half, and
 `examples/actions/` holds working ones.
 
+> **Experimental.** This surface may change in ways a minor release normally
+> would not, and an upgrade may require editing actions you have written. The
+> unsettled part is `UINode` itself — how an element is identified, and how
+> long a node you are holding stays valid — which is the shape everything
+> below is built on. The rest of Keyhac's API is not affected; see
+> [Authoring actions with Claude](mcp.md) for what this covers and what it
+> would take to settle it.
+
 **Cross-platform by shape, not by data.** Every method here exists and behaves
 the same on Windows and macOS. What differs is the tree it reads: roles are
 `AXTable` / `Table`, macOS keeps a control's state in one value where Windows

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -339,6 +339,13 @@ action drives somebody else's UI, and only `UINode`, `WaitTimeout` and
 `FillFailed` are importable. **See [Action API](action_api.md)** for the full
 surface, and `keyhac/skills/action-authoring/` for how to write one.
 
+**This surface is experimental** and the rest of this document is not: it may
+change in ways a minor release normally would not, and an upgrade may require
+editing actions you have written. Everything else here — key tables, clipboard
+history, macros, window control — keeps the stability you expect from a 2.x
+release. [Authoring actions with Claude](mcp.md) says what is unsettled and
+what would settle it.
+
 ## Keyboard macros
 
 ```python

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -1033,6 +1033,18 @@ Latency budget:
 
 ## 14. What is built (2026-08-07)
 
+**Shipped as experimental**, from the release that merged this work. The
+plumbing is done and the experience is not: what argues for shipping is that
+it is off by default and additive, so it costs nothing to anyone who leaves it
+alone, and that §11's remaining question — `UINode`'s element identity and
+handle lifetime — will be settled by people writing real actions rather than
+by more design. What argues against calling it finished is on this page: layer
+3 is partial in exactly the places §2's workload needs (no cancellation, no
+`preconditions()`, the `max_workers=1` pool), layer 5 does not exist so a hand
+edit of `config.py` is still the transport, and the whole generation record is
+two sessions on one macOS machine with no Windows generation at all. The
+marker comes off when that shape stops moving, not when the backlog empties.
+
 Against the layers in §5 and the sequence in §10:
 
 | | State |

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -9,6 +9,28 @@ handing you code to debug.
 you do: the endpoint reads the accessibility tree of every application you have
 open and can run the actions you register. See [Security](#security).
 
+> ### Experimental
+>
+> This feature — the MCP endpoint, the [action API](action_api.md), the
+> authoring skill — is **experimental**, and the rest of Keyhac is not. Key
+> tables, clipboard history, macros and window control keep the stability you
+> expect from a 2.x release; this does not.
+>
+> **What that means in practice:** an upgrade may require editing actions you
+> have already written. The usual rule that a minor release only *adds* does
+> not apply here. In particular the shape of a `UINode` — how an element is
+> identified, and how long a node you are holding stays valid — is not
+> settled, and it is the shape everything else is built on.
+>
+> **Why it is shipped anyway:** it is off by default and additive, so it costs
+> nothing to anyone who does not enable it, and the shape will be settled by
+> people writing real actions rather than by more design. If you write some,
+> what broke is the useful report.
+>
+> It stops being experimental when that shape stops moving — which needs, at
+> minimum, actions generated against Windows as well as macOS, and by more
+> than one person. Today the evidence is two sessions on one machine.
+
 ## Turning it on
 
 In `~/.keyhac/config.py`:

--- a/tools/generate_api_reference.py
+++ b/tools/generate_api_reference.py
@@ -126,6 +126,14 @@ Generated from the docstrings. For how to *write* an action, the authoring
 skill in `keyhac/skills/action-authoring/` is the procedural half, and
 `examples/actions/` holds working ones.
 
+> **Experimental.** This surface may change in ways a minor release normally
+> would not, and an upgrade may require editing actions you have written. The
+> unsettled part is `UINode` itself — how an element is identified, and how
+> long a node you are holding stays valid — which is the shape everything
+> below is built on. The rest of Keyhac's API is not affected; see
+> [Authoring actions with Claude](mcp.md) for what this covers and what it
+> would take to settle it.
+
 **Cross-platform by shape, not by data.** Every method here exists and behaves
 the same on Windows and macOS. What differs is the tree it reads: roles are
 `AXTable` / `Table`, macOS keeps a control's state in one value where Windows


### PR DESCRIPTION
Shipping the AI-integration surface freezes it, and one open question gets
*harder* after a release rather than easier: how a `UINode` identifies an
element, and how long a node you are holding stays valid (§11 of
`doc/dev/ai-integration.md`). Every action is written against that shape.
Everything else outstanding — the `max_workers=1` pool, the missing
cancellation and `preconditions()`, layer 5, the nine-step install — costs the
same to fix whenever it is fixed.

So: a marker, rather than either holding the release or pretending the question
is closed.

**It is a claim about API stability and nothing else.** Each notice says
outright that key tables, clipboard history, macros and window control keep the
stability a 2.x release implies, and that this surface does not. Marking a whole
release unstable to cover one subsystem would be the more damaging error.

**Each notice names what may change**, rather than disclaiming generally — it is
`UINode`, not the MCP tool schemas or `wait_for`, and that distinction is what
tells a reader whether their actions survive an upgrade. It also states the exit
condition: actions generated against Windows as well as macOS, by more than one
person, where today the record is two sessions on one machine.

### Where, and why there

| File | Why |
|---|---|
| `doc/mcp.md` | Long form, immediately before the instructions for turning it on — the last moment the decision is still free |
| `doc/action_api.md` | Generated, so the note went into `ACTION_HEADER` in the generator; editing the output would be reverted by the next `make api-reference` |
| `doc/configuration.md` | Short form where `keymap.ui` is introduced; that document is linked from the README and its reader has no reason to open `mcp.md` |
| `CLAUDE.md` | So a coding agent does not treat the surface as frozen — and, as importantly, does not spread the marker to the rest of the codebase |
| `doc/dev/ai-integration.md` §14 | "Shipped as experimental" is a conclusion; this page is where its evidence lives |

**Not added to `README.md`.** Its Documentation list links neither `mcp.md` nor
`action_api.md` today, so the feature is not advertised there at all; adding
links would make a just-marked-experimental surface more prominent. Worth
revisiting when the marker comes off.

### Checks

- `make api-reference-check` — `doc/action_api.md` is up to date
- `pytest` — 362 passed, 16 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)