### PR TITLE
The MCP endpoint is a visible switch, and not Claude's alone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,10 @@ verification record — including which passes caught which real bugs — is in
 [doc/dev/testing.md](doc/dev/testing.md).
 
 **AI integration ships as experimental** — the MCP endpoint (`keyhac/mcp/`), the
-action API (`keymap.ui`, `UINode`) and the authoring skill. It is off unless a
-config calls `enable_mcp_server()`, and it is the one part of the public surface
+action API (`keymap.ui`, `UINode`) and the authoring skill. It is off unless the
+user ticks **MCP server** in the console or tray menu (persisted in
+`settings.json`; there is deliberately no config API), and it is the one part of
+the public surface
 **not** covered by the usual additive-only expectation: `UINode`'s element
 identity and handle lifetime are still open ([doc/dev/ai-integration.md](doc/dev/ai-integration.md)
 §11), and settling them may break actions. Do not treat that surface as frozen,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ verification record — including which passes caught which real bugs — is in
 
 **AI integration ships as experimental** — the MCP endpoint (`keyhac/mcp/`), the
 action API (`keymap.ui`, `UINode`) and the authoring skill. It is off unless the
-user ticks **MCP server** in the console or tray menu (persisted in
+user ticks **AI Integration > MCP Server** in the console or tray menu (persisted in
 `settings.json`; there is deliberately no config API), and it is the one part of
 the public surface
 **not** covered by the usual additive-only expectation: `UINode`'s element

--- a/doc/action_api.md
+++ b/doc/action_api.md
@@ -15,7 +15,7 @@ skill in `keyhac/skills/action-authoring/` is the procedural half, and
 > unsettled part is `UINode` itself — how an element is identified, and how
 > long a node you are holding stays valid — which is the shape everything
 > below is built on. The rest of Keyhac's API is not affected; see
-> [Authoring actions with Claude](mcp.md) for what this covers and what it
+> [Authoring actions with an AI agent](mcp.md) for what this covers and what it
 > would take to settle it.
 
 **Cross-platform by shape, not by data.** Every method here exists and behaves

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -44,6 +44,14 @@ Portable snapshot of the current keyboard focus (a Focus), or None before the fi
 
 ---
 
+#### <kbd>property</kbd> Keymap.mcp_server_running
+
+Whether the endpoint is currently listening. 
+
+lazydocs: ignore 
+
+---
+
 #### <kbd>property</kbd> Keymap.registered_actions
 
 The actions registered by name, for the MCP tools to list and run. 
@@ -167,24 +175,6 @@ edit_config() → None
 Open the configuration file in a text editor. 
 
 ``keymap.editor`` chooses the editor: an application name or path the OS can resolve, or a callable receiving the config path.  Left empty, a platform default is used (Visual Studio Code / Xcode / TextEdit on macOS, Notepad on Windows).  The tray menu's "Edit Config" item calls this. 
-
----
-
-### <kbd>method</kbd> `Keymap.enable_mcp_server`
-
-```python
-enable_mcp_server(port: int = 0) → None
-```
-
-Serve the action-authoring tools on localhost, for Claude to use. 
-
-**Off unless a configuration calls this.** The endpoint reads the UI tree and can run registered actions, so it binds to 127.0.0.1 only and every request carries a token published - readable by this user alone - beside the configuration. `keyhac-mcp-bridge` reads that file; nothing else needs to know the port. 
-
-
-
-**Args:**
- 
- - <b>`port`</b>:  TCP port, or 0 to let the OS choose (the default - the bridge  reads whichever port was chosen, so a fixed one buys nothing  but a collision). 
 
 ---
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -343,7 +343,7 @@ surface, and `keyhac/skills/action-authoring/` for how to write one.
 change in ways a minor release normally would not, and an upgrade may require
 editing actions you have written. Everything else here — key tables, clipboard
 history, macros, window control — keeps the stability you expect from a 2.x
-release. [Authoring actions with Claude](mcp.md) says what is unsettled and
+release. [Authoring actions with an AI agent](mcp.md) says what is unsettled and
 what would settle it.
 
 ## Keyboard macros

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -48,8 +48,8 @@ every window and can run your actions should be visibly on or visibly off; a
 line in the middle of a several-hundred-line `config.py` tells you what was
 asked for once, and nothing about what is true now. The same reasoning already
 governs the keyboard hook, which has always been a checkbox rather than a
-setting. *(`keymap.enable_mcp_server()` existed in 2.2.0 and is gone; delete
-the line and use the switch.)*
+setting. *(2.2.0 had a `keymap.enable_mcp_server()` call for this. It is gone —
+delete the line from your `config.py` and use the switch.)*
 
 ## Connecting an agent
 

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -39,9 +39,9 @@ open and can run the actions you register. See [Security](#security).
 
 ## Turning it on
 
-Tick **MCP server** in the console window, or the item of the same name in the
-tray / menu bar menu. The console logs the port it chose, and the choice is
-remembered across restarts.
+Tick **MCP server** under **AI Integration** in the console window, or
+**AI Integration → MCP Server** in the tray / menu bar menu. The console logs
+the port it chose, and the choice is remembered across restarts.
 
 There is deliberately no configuration API for this. An endpoint that reads
 every window and can run your actions should be visibly on or visibly off; a
@@ -208,8 +208,8 @@ don't type passwords or show private material while recording.
 ## Security
 
 - **Off by default**, and the switch is visible. Nothing listens until you tick
-  **MCP server**, and while it is on the checkbox and the menu item both say
-  so — which a line in a config file cannot.
+  **AI Integration → MCP server**, and while it is on the checkbox and the menu
+  item both say so — which a line in a config file cannot.
 - **Loopback only**, with a token generated at each start and published in
   `mcp.json` beside your config, readable only by you. The bridge reads it;
   another process on the machine cannot use the endpoint without it.

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -1,9 +1,15 @@
-# Authoring actions with Claude
+# Authoring actions with an AI agent
 
-Keyhac can expose its element tools to Claude over MCP, so you can ask for an
-action in a chat window and have Claude inspect the actual screen, write it,
-run it, read the error, and fix it — instead of guessing at selectors and
-handing you code to debug.
+Keyhac can expose its element tools over MCP, so you can ask for an action in a
+chat window and have the agent inspect the actual screen, write it, run it,
+read the error, and fix it — instead of guessing at selectors and handing you
+code to debug.
+
+MCP is an open protocol and nothing here is specific to one vendor: Keyhac
+serves ordinary JSON-RPC over loopback HTTP with a bearer token, which is a
+plain Streamable HTTP endpoint. Any client that can reach one should work.
+[Connecting an agent](#connecting-an-agent) lists which have actually been
+tried, which is a shorter list.
 
 **This is off unless you turn it on**, and it is worth understanding why before
 you do: the endpoint reads the accessibility tree of every application you have
@@ -33,17 +39,47 @@ open and can run the actions you register. See [Security](#security).
 
 ## Turning it on
 
-In `~/.keyhac/config.py`:
+Tick **MCP server** in the console window, or the item of the same name in the
+tray / menu bar menu. The console logs the port it chose, and the choice is
+remembered across restarts.
 
-```python
-def configure(keymap):
-    keymap.enable_mcp_server()
-```
+There is deliberately no configuration API for this. An endpoint that reads
+every window and can run your actions should be visibly on or visibly off; a
+line in the middle of a several-hundred-line `config.py` tells you what was
+asked for once, and nothing about what is true now. The same reasoning already
+governs the keyboard hook, which has always been a checkbox rather than a
+setting. *(`keymap.enable_mcp_server()` existed in 2.2.0 and is gone; delete
+the line and use the switch.)*
 
-Reload (tray → Reload Config). The console logs the port it chose.
+## Connecting an agent
 
-Then register the bridge with Claude Desktop — Settings → Developer → Edit
-Config, or `~/Library/Application Support/Claude/claude_desktop_config.json`:
+| Client | Transport | Status |
+|---|---|---|
+| Claude Desktop | stdio → the bridge below | **Verified** — the actions in `examples/actions/` were authored through it |
+| Claude Code | HTTP directly (`claude mcp add --transport http`) | Should work, **untried** |
+| Anything else with MCP support | HTTP directly | Should work, **untried** |
+
+"Untried" is not scepticism about those clients — nobody has run them against
+this endpoint yet. If you do, whether it worked or not is the useful report.
+
+**Connecting over HTTP directly**, for a client that can: the port and token
+are published in `mcp.json` beside your `config.py`, the endpoint is
+`http://127.0.0.1:<port>/`, and every request must carry
+`Authorization: Bearer <token>`. The port is chosen at each start, so read the
+file rather than pinning a number.
+
+### The bridge, for stdio-only clients
+
+Claude Desktop starts a local MCP server as a child process and talks JSON-RPC
+over its stdin/stdout. Keyhac cannot be that child — it is a resident daemon
+holding the keyboard hook and your focus history, and a second copy per
+conversation would be a second hook and a second accessibility prompt. So
+`keyhac-mcp-bridge` runs as the child instead and forwards to the daemon
+already running. It holds no tool definitions and no logic, so the two cannot
+drift apart.
+
+Register it — Settings → Developer → Edit Config, or
+`~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -68,19 +104,19 @@ source checkout (`python -m keyhac`) does not create one at all. Find it with
 ```
 
 The bridge does not have to come from the same install as the daemon — it reads
-the endpoint file and forwards, and holds no tool definitions of its own.
-
-**Why a bridge at all**: Claude Desktop starts a local MCP server as a child
-process, and Keyhac cannot be that child — it is a resident daemon holding the
-keyboard hook and your focus history. The bridge is a shim that forwards to the
-Keyhac already running; it holds no logic of its own.
+the endpoint file and forwards.
 
 ## Add the authoring skill
 
-The tools tell Claude what your screen contains. The skill tells it how to
+The tools tell the agent what your screen contains. The skill tells it how to
 write an action — the rules that stop it emitting `sleep`, coordinates, and
 unverified writes. Without it you will get plausible code that breaks on a
 slower machine.
+
+Skills are a Claude feature, so the packaged bundle is for Claude Desktop.
+The content is not: `keyhac/skills/action-authoring/` is Markdown, and any
+agent that can be given documents can be given these. What it cannot be given
+is the *habit* of consulting them unprompted, which is the part a skill buys.
 
 Claude Desktop → Settings → カスタマイズ / Customize → Skills → Add → **Upload
 skill**, and give it the bundle:
@@ -102,11 +138,11 @@ is visible.
 **The skill is not the connection, and neither step implies the other.** The
 skill is knowledge — writing rules and an API reference, with no way to reach
 your machine; the tools come from the bridge registered above. Upload only the
-skill and Claude will correctly tell you it cannot see your windows. Register
-only the bridge and it will see them, then write actions that use `sleep` and
+skill and the agent will correctly tell you it cannot see your windows. Connect
+only the tools and it will see them, then write actions that use `sleep` and
 screen coordinates.
 
-## What Claude can do
+## What the agent can do
 
 | Tool | |
 |---|---|
@@ -124,8 +160,8 @@ screen coordinates.
 keymap.register_action("extract_records", ExtractRecords())
 ```
 
-Registering is per-action and opt-in — it is the line between "Claude can run
-this" and "Claude can run anything the config defines".
+Registering is per-action and opt-in — it is the line between "the agent can
+run this" and "the agent can run anything the config defines".
 
 ## The loop
 
@@ -133,9 +169,9 @@ this" and "Claude can run anything the config defines".
 2. Ask for what you want, in your own words. Naming the application and the
    output is useful; naming an API is not — if you find yourself typing
    `find_element`, tell us, because that means the skill is failing.
-3. Claude reads the screen and writes the action.
-4. Paste it into `config.py` (or an imported module), register it, and ask
-   Claude to reload and run it.
+3. The agent reads the screen and writes the action.
+4. Paste it into `config.py` (or an imported module), register it, and ask it
+   to reload and run it.
 5. It reads the failure itself and fixes it.
 
 Step 4 is manual for now: no tool writes Python to your disk, deliberately.
@@ -171,7 +207,9 @@ don't type passwords or show private material while recording.
 
 ## Security
 
-- **Off by default.** Nothing listens until `enable_mcp_server()` is called.
+- **Off by default**, and the switch is visible. Nothing listens until you tick
+  **MCP server**, and while it is on the checkbox and the menu item both say
+  so — which a line in a config file cannot.
 - **Loopback only**, with a token generated at each start and published in
   `mcp.json` beside your config, readable only by you. The bridge reads it;
   another process on the machine cannot use the endpoint without it.
@@ -179,5 +217,5 @@ don't type passwords or show private material while recording.
   an app you are looking at is one thing; letting a remote model put Python on
   your disk is another decision, and it has not been made.
 - **`run_action` is limited to registered actions**, by name.
-- Turn it off by removing the call and reloading; the token file is deleted
-  when Keyhac stops.
+- Turn it off with the same switch; the token file is deleted then, and when
+  Keyhac stops.

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -810,18 +810,49 @@ class Keymap:
         return dict(self._registered_actions)
 
     def enable_mcp_server(self, port: int = 0) -> None:
-        """Serve the action-authoring tools on localhost, for Claude to use.
+        """Removed in 2.3.0 - the endpoint is switched from the UI now.
 
-        **Off unless a configuration calls this.** The endpoint reads the UI
-        tree and can run registered actions, so it binds to 127.0.0.1 only and
+        Kept for one release so a configuration written against 2.2.0's
+        documentation fails with an instruction rather than an AttributeError.
+
+        lazydocs: ignore
+        """
+        raise RuntimeError(
+            "keymap.enable_mcp_server() has been removed. The MCP server is "
+            "switched on from the console's 'MCP server' checkbox or the same "
+            "item in the tray menu, and the choice is remembered across "
+            "restarts - delete this line from your configuration. See "
+            "doc/mcp.md.")
+
+    @property
+    def mcp_server_running(self) -> bool:
+        """Whether the endpoint is currently listening.
+
+        lazydocs: ignore
+        """
+        return self._mcp_server is not None
+
+    def start_mcp_server(self, port: int = 0) -> None:
+        """Start the action-authoring endpoint on localhost.
+
+        The switch is the console's **MCP server** checkbox, or the same item
+        in the tray menu; this is the mechanism behind it. There is
+        deliberately no configuration API: an endpoint that reads every window
+        and can run registered actions should be visibly on or visibly off,
+        and a line in the middle of a config file tells you what was asked for
+        once, never what is true now.
+
+        Off until something asks. The endpoint binds to 127.0.0.1 only and
         every request carries a token published - readable by this user alone -
         beside the configuration. `keyhac-mcp-bridge` reads that file; nothing
         else needs to know the port.
 
         Args:
-            port: TCP port, or 0 to let the OS choose (the default - the bridge
-                reads whichever port was chosen, so a fixed one buys nothing
+            port: TCP port, or 0 to let the OS choose (the default - clients
+                read whichever port was chosen, so a fixed one buys nothing
                 but a collision).
+
+        lazydocs: ignore
         """
         if self._mcp_server is not None:
             return

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -819,10 +819,10 @@ class Keymap:
         """
         raise RuntimeError(
             "keymap.enable_mcp_server() has been removed. The MCP server is "
-            "switched on from the console's 'MCP server' checkbox or the same "
-            "item in the tray menu, and the choice is remembered across "
-            "restarts - delete this line from your configuration. See "
-            "doc/mcp.md.")
+            "switched on from the console window's 'AI Integration' "
+            "checkbox, or Tray menu > AI Integration > MCP Server, and the "
+            "choice is remembered across restarts - delete this line from "
+            "your configuration. See doc/mcp.md.")
 
     @property
     def mcp_server_running(self) -> bool:
@@ -835,8 +835,8 @@ class Keymap:
     def start_mcp_server(self, port: int = 0) -> None:
         """Start the action-authoring endpoint on localhost.
 
-        The switch is the console's **MCP server** checkbox, or the same item
-        in the tray menu; this is the mechanism behind it. There is
+        The switch is the console's **AI Integration** checkbox, or the tray
+        menu's *AI Integration > MCP Server*; this is the mechanism behind it. There is
         deliberately no configuration API: an endpoint that reads every window
         and can run registered actions should be visibly on or visibly off,
         and a line in the middle of a config file tells you what was asked for

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -809,21 +809,6 @@ class Keymap:
         """The actions registered by name, for the MCP tools to list and run."""
         return dict(self._registered_actions)
 
-    def enable_mcp_server(self, port: int = 0) -> None:
-        """Removed in 2.3.0 - the endpoint is switched from the UI now.
-
-        Kept for one release so a configuration written against 2.2.0's
-        documentation fails with an instruction rather than an AttributeError.
-
-        lazydocs: ignore
-        """
-        raise RuntimeError(
-            "keymap.enable_mcp_server() has been removed. The MCP server is "
-            "switched on from the console window's 'AI Integration' "
-            "checkbox, or Tray menu > AI Integration > MCP Server, and the "
-            "choice is remembered across restarts - delete this line from "
-            "your configuration. See doc/mcp.md.")
-
     @property
     def mcp_server_running(self) -> bool:
         """Whether the endpoint is currently listening.
@@ -836,8 +821,9 @@ class Keymap:
         """Start the action-authoring endpoint on localhost.
 
         The switch is the console's **AI Integration** checkbox, or the tray
-        menu's *AI Integration > MCP Server*; this is the mechanism behind it. There is
-        deliberately no configuration API: an endpoint that reads every window
+        menu's *AI Integration > MCP Server*; this is the mechanism behind it.
+        There is deliberately no configuration API: an endpoint that reads every
+        window
         and can run registered actions should be visibly on or visibly off,
         and a line in the middle of a config file tells you what was asked for
         once, never what is true now.

--- a/keyhac/main.py
+++ b/keyhac/main.py
@@ -110,13 +110,21 @@ def main() -> int:
 
     keymap.configure()
 
+    # Settings in both modes, because the MCP endpoint's on/off lives here now
+    # and headless has no menu to set it from. --no-ui cannot *change* the
+    # switch; it honours what the UI last set, which keeps one source of truth
+    # rather than growing a second one for a mode that has no UI.
+    from keyhac.core.settings import Settings
+    settings = Settings(app_paths.state_file("settings.json"))
+    if settings.get("mcp_server", False):
+        keymap.start_mcp_server()
+
     if args.no_ui:
         return _run_headless(keymap, hook, native_loop, platform_name,
                              clipboard_provider)
 
-    from keyhac.core.settings import Settings
     return _run_with_console(keymap, hook, platform_name, clipboard_provider,
-                             Settings(app_paths.state_file("settings.json")))
+                             settings)
 
 
 def _run_with_console(keymap, hook, platform_name: str, clipboard_provider,

--- a/keyhac/mcp/bridge.py
+++ b/keyhac/mcp/bridge.py
@@ -92,8 +92,8 @@ def main(argv: list[str] | None = None) -> int:
             _respond(message, _error(
                 request_id,
                 f"Keyhac's MCP endpoint is not available ({path}). Is Keyhac "
-                f"running, and does its config.py call "
-                f"keymap.enable_mcp_server()?"))
+                f"running, and is its 'MCP server' switch on - the checkbox "
+                f"in the console window, or the item in the tray menu?"))
             continue
 
         request = urllib.request.Request(

--- a/keyhac/mcp/bridge.py
+++ b/keyhac/mcp/bridge.py
@@ -92,8 +92,9 @@ def main(argv: list[str] | None = None) -> int:
             _respond(message, _error(
                 request_id,
                 f"Keyhac's MCP endpoint is not available ({path}). Is Keyhac "
-                f"running, and is its 'MCP server' switch on - the checkbox "
-                f"in the console window, or the item in the tray menu?"))
+                f"running, and is its MCP server switch on - the 'AI "
+                f"Integration' checkbox in the console window, or the same "
+                f"item in the tray menu?"))
             continue
 
         request = urllib.request.Request(

--- a/keyhac/mcp/server.py
+++ b/keyhac/mcp/server.py
@@ -92,6 +92,29 @@ class _Handler(BaseHTTPRequestHandler):
             return
         self._send(200, response)
 
+    def do_GET(self):                                    # noqa: N802 - stdlib
+        self._decline()
+
+    def do_DELETE(self):                                 # noqa: N802 - stdlib
+        self._decline()
+
+    def _decline(self) -> None:
+        """405, not the stdlib's 501, for the verbs this transport declines.
+
+        Streamable HTTP lets a server offer no server-to-client SSE stream and
+        no sessions - but it has to decline in the spec's words: GET without a
+        stream "MUST return HTTP 405", and DELETE is how a client ends a
+        session it was never given. The stdlib's default 501 says something
+        else entirely - *this server does not implement HTTP* - and a client
+        that opens the optional stream before its first tool call can read that
+        as fatal rather than as "no stream here". The distinction only matters
+        for clients other than the bridge, which is exactly who this is for.
+        """
+        self.send_response(405)
+        self.send_header("Allow", "POST")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
     def _authorised(self) -> bool:
         header = self.headers.get("Authorization", "")
         prefix = "Bearer "

--- a/keyhac/ui/console.py
+++ b/keyhac/ui/console.py
@@ -123,8 +123,16 @@ class ConsoleWindow:
         # Beside the hook checkbox on purpose: both switch a capability the
         # user is entitled to see the state of, and the endpoint being visibly
         # off is most of the answer to "is this thing watching me".
+        #
+        # The category is folded into the label rather than standing beside it
+        # as its own text. A checkbox draws its box on the left and its label
+        # on the right, so a separate "AI Integration:" landed between the two
+        # checkboxes and read as a third peer in the row - it appeared to label
+        # the box that followed it only if you already knew that was the
+        # intent. A menu gets hierarchy from nesting; a flat row has to spell
+        # it, and this spells the same path the menu shows.
         self._mcp_checkbox = Checkbox(
-            "MCP server", checked=keymap.mcp_server_running,
+            "AI Integration: MCP server", checked=keymap.mcp_server_running,
             on_change=self._on_mcp_toggle)
         self._level_dropdown = DropDown(
             [name for name, _lvl in _LEVELS],
@@ -153,7 +161,6 @@ class ConsoleWindow:
         toolbar = HSplit(
             Item(self._hook_checkbox, size="content", align="center"),
             Item(Label(""), size=3),
-            Item(Label("AI Integration:"), size="content", align="center"),
             Item(self._mcp_checkbox, size="content", align="center"),
             Item(Label(""), weight=1),
             Item(Label("Log level:"), size="content", align="center"),

--- a/keyhac/ui/console.py
+++ b/keyhac/ui/console.py
@@ -120,6 +120,12 @@ class ConsoleWindow:
 
         self._hook_checkbox = Checkbox(
             "Keyboard hook", checked=hook.installed, on_change=self._on_hook_toggle)
+        # Beside the hook checkbox on purpose: both switch a capability the
+        # user is entitled to see the state of, and the endpoint being visibly
+        # off is most of the answer to "is this thing watching me".
+        self._mcp_checkbox = Checkbox(
+            "MCP server", checked=keymap.mcp_server_running,
+            on_change=self._on_mcp_toggle)
         self._level_dropdown = DropDown(
             [name for name, _lvl in _LEVELS],
             selected=initial_level_index,
@@ -142,6 +148,7 @@ class ConsoleWindow:
         # this row is label <-> dropdown; keep it tight.
         toolbar = HSplit(
             Item(self._hook_checkbox, size="content", align="center"),
+            Item(self._mcp_checkbox, size="content", align="center"),
             Item(Label(""), weight=1),
             Item(Label("Log level:"), size="content", align="center"),
             Item(self._level_dropdown, size="content", align="center"),
@@ -288,6 +295,27 @@ class ConsoleWindow:
                     self._hook_checkbox.checked = False
         else:
             self._hook.uninstall()
+
+    def _on_mcp_toggle(self, checked: bool) -> None:
+        # Persisted before it is acted on, so a start that throws still leaves
+        # the setting matching what the user asked for - and reverted with it
+        # if the start fails, because a checkbox that says "on" over a socket
+        # that never bound is the one state this switch must not reach.
+        if self._settings is not None:
+            self._settings.set("mcp_server", checked)
+        try:
+            if checked:
+                self._keymap.start_mcp_server()
+                logger.info("MCP server enabled.")
+            else:
+                self._keymap.stop_mcp_server()
+                logger.info("MCP server disabled.")
+        except Exception as e:
+            logger.error(f"Could not {'start' if checked else 'stop'} "
+                         f"the MCP server: {e}")
+            if self._settings is not None:
+                self._settings.set("mcp_server", not checked)
+            self._mcp_checkbox.checked = self._keymap.mcp_server_running
 
     def _on_level_change(self, index: int, name: str) -> None:
         self._console.log_level = _LEVELS[index][1]

--- a/keyhac/ui/console.py
+++ b/keyhac/ui/console.py
@@ -144,10 +144,16 @@ class ConsoleWindow:
         # breathing room between the rows, inspector labels on a shared fixed
         # width so the values line up, and the toolbar/label rows centered on
         # their cross axis.
-        # The flexible spacer absorbs the middle, so the only visible gap in
-        # this row is label <-> dropdown; keep it tight.
+        # The flexible spacer absorbs the middle, so the only visible gaps in
+        # this row are label <-> control; keep those tight.
+        # The fixed spacer is not decoration: at the shared 0.3 gap "Keyboard
+        # hook" and the next group read as one run of text, and the checkbox
+        # that belongs to which label becomes a guess. It buys the separation
+        # the grouping is claiming.
         toolbar = HSplit(
             Item(self._hook_checkbox, size="content", align="center"),
+            Item(Label(""), size=3),
+            Item(Label("AI Integration:"), size="content", align="center"),
             Item(self._mcp_checkbox, size="content", align="center"),
             Item(Label(""), weight=1),
             Item(Label("Log level:"), size="content", align="center"),

--- a/keyhac/ui/tray.py
+++ b/keyhac/ui/tray.py
@@ -47,8 +47,15 @@ def install_tray(console, keymap, hook) -> None:
         MenuItem("Reload Config", on_select=keymap.configure),
         MenuItem("Keyboard Hook", on_select=toggle_hook,
                  checked=lambda: hook.installed),
-        MenuItem("MCP Server", on_select=toggle_mcp,
-                 checked=lambda: keymap.mcp_server_running),
+        # Nested under a name that means something to someone who has never
+        # heard of MCP. "MCP Server" at the top level is a row most users
+        # cannot evaluate - they can neither want it nor avoid it - whereas
+        # "AI Integration" says what the whole branch is for, and anyone who
+        # needs the protocol's name finds it one level in.
+        MenuItem("AI Integration", submenu=Menu(
+            MenuItem("MCP Server", on_select=toggle_mcp,
+                     checked=lambda: keymap.mcp_server_running),
+        )),
         SEPARATOR,
         MenuItem("Quit Keyhac", on_select=console.backend.quit),
     )

--- a/keyhac/ui/tray.py
+++ b/keyhac/ui/tray.py
@@ -33,12 +33,22 @@ def install_tray(console, keymap, hook) -> None:
         console._hook_checkbox.checked = hook.installed
         console.panel.render()
 
+    def toggle_mcp():
+        # Through the console's handler rather than the keymap's, so the
+        # setting is written and the checkbox follows from one place - the two
+        # switches are one switch with two faces.
+        console._on_mcp_toggle(not keymap.mcp_server_running)
+        console._mcp_checkbox.checked = keymap.mcp_server_running
+        console.panel.render()
+
     menu = Menu(
         MenuItem("Open Console", on_select=console.backend.show_main_window),
         MenuItem("Edit Config", on_select=keymap.edit_config),
         MenuItem("Reload Config", on_select=keymap.configure),
         MenuItem("Keyboard Hook", on_select=toggle_hook,
                  checked=lambda: hook.installed),
+        MenuItem("MCP Server", on_select=toggle_mcp,
+                 checked=lambda: keymap.mcp_server_running),
         SEPARATOR,
         MenuItem("Quit Keyhac", on_select=console.backend.quit),
     )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -317,8 +317,12 @@ def test_the_removed_config_call_says_where_the_switch_went(tmp_path):
     keymap = _real_keymap(tmp_path)
     with pytest.raises(RuntimeError) as caught:
         keymap.enable_mcp_server()
-    assert "tray menu" in str(caught.value)
-    assert "console" in str(caught.value)
+    # Case-insensitive: the point is that both faces of the switch are named,
+    # not how the sentence happens to capitalise them.
+    message = str(caught.value).lower()
+    assert "tray menu" in message
+    assert "console" in message
+    assert "ai integration" in message, "the label it is filed under"
 
 
 # -- the bridge -------------------------------------------------------------

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -310,21 +310,6 @@ def test_the_switch_reports_and_moves(tmp_path):
     assert keymap.mcp_server_running is False
 
 
-def test_the_removed_config_call_says_where_the_switch_went(tmp_path):
-    """A config written against 2.2.0's documentation still exists in the
-    world; it should fail with an instruction, not an AttributeError. Delete
-    this test and the shim together in 2.3.0."""
-    keymap = _real_keymap(tmp_path)
-    with pytest.raises(RuntimeError) as caught:
-        keymap.enable_mcp_server()
-    # Case-insensitive: the point is that both faces of the switch are named,
-    # not how the sentence happens to capitalise them.
-    message = str(caught.value).lower()
-    assert "tray menu" in message
-    assert "console" in message
-    assert "ai integration" in message, "the label it is filed under"
-
-
 # -- the bridge -------------------------------------------------------------
 
 def test_the_bridge_explains_a_missing_daemon(tmp_path, capsys, monkeypatch):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -265,6 +265,62 @@ def test_it_binds_loopback_only(server):
     assert server._server.server_address[0] == "127.0.0.1"
 
 
+@pytest.mark.parametrize("method", ["GET", "DELETE"])
+def test_the_declined_verbs_answer_405_and_not_501(server, method):
+    """Streamable HTTP lets a server offer no SSE stream and no sessions, but
+    the refusal has to be 405: a client that opens the optional server stream
+    before its first tool call reads the stdlib's default 501 as "this server
+    does not implement HTTP" rather than "no stream here". Only clients other
+    than the bridge ever send these, which is exactly who this is for."""
+    request = urllib.request.Request(f"http://127.0.0.1:{server.port}/",
+                                     method=method)
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        urllib.request.urlopen(request, timeout=10)
+    assert caught.value.code == 405
+    assert caught.value.headers.get("Allow") == "POST"
+
+
+# -- the switch -------------------------------------------------------------
+
+def _real_keymap(tmp_path):
+    from keyhac.core.keymap import Keymap
+    from keyhac.platform.fake import FakeFocusProvider
+    from tests.conftest import FakeInputHook
+
+    config = tmp_path / "config.py"
+    config.write_text("def configure(keymap):\n    pass\n")
+    keymap = Keymap(FakeInputHook("ansi"), FakeFocusProvider(), "mac",
+                    config_path=str(config), template_path=str(config))
+    keymap.configure()
+    return keymap
+
+
+def test_the_switch_reports_and_moves(tmp_path):
+    """`mcp_server_running` is what both faces of the switch read to draw
+    themselves, so it has to follow the socket rather than the request."""
+    keymap = _real_keymap(tmp_path)
+    assert keymap.mcp_server_running is False
+    keymap.start_mcp_server()
+    try:
+        assert keymap.mcp_server_running is True
+        keymap.start_mcp_server()          # idempotent: the menu can double-fire
+        assert keymap.mcp_server_running is True
+    finally:
+        keymap.stop_mcp_server()
+    assert keymap.mcp_server_running is False
+
+
+def test_the_removed_config_call_says_where_the_switch_went(tmp_path):
+    """A config written against 2.2.0's documentation still exists in the
+    world; it should fail with an instruction, not an AttributeError. Delete
+    this test and the shim together in 2.3.0."""
+    keymap = _real_keymap(tmp_path)
+    with pytest.raises(RuntimeError) as caught:
+        keymap.enable_mcp_server()
+    assert "tray menu" in str(caught.value)
+    assert "console" in str(caught.value)
+
+
 # -- the bridge -------------------------------------------------------------
 
 def test_the_bridge_explains_a_missing_daemon(tmp_path, capsys, monkeypatch):
@@ -279,7 +335,7 @@ def test_the_bridge_explains_a_missing_daemon(tmp_path, capsys, monkeypatch):
                         io.StringIO('{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n'))
     bridge.main([])
     reply = json.loads(capsys.readouterr().out)
-    assert "enable_mcp_server" in reply["error"]["message"]
+    assert "MCP server" in reply["error"]["message"]
 
 
 def test_a_hollow_web_area_points_at_content_access(registry):

--- a/tools/generate_api_reference.py
+++ b/tools/generate_api_reference.py
@@ -131,7 +131,7 @@ skill in `keyhac/skills/action-authoring/` is the procedural half, and
 > unsettled part is `UINode` itself — how an element is identified, and how
 > long a node you are holding stays valid — which is the shape everything
 > below is built on. The rest of Keyhac's API is not affected; see
-> [Authoring actions with Claude](mcp.md) for what this covers and what it
+> [Authoring actions with an AI agent](mcp.md) for what this covers and what it
 > would take to settle it.
 
 **Cross-platform by shape, not by data.** Every method here exists and behaves


### PR DESCRIPTION
Two changes that turned out to be one, plus the conformance bug the second
uncovered.

### The switch

`keymap.enable_mcp_server()` is **removed**. The endpoint is switched from
**AI Integration: MCP server** in the console, or **AI Integration → MCP
Server** in the tray menu, and the choice persists in `settings.json`.

§4.4 still wants this deliberate — but a line in the middle of a
several-hundred-line config tells you what was asked for once and nothing about
what is true now, and "is this thing watching me" is a question this
application has to answer continuously. The precedent was already in the tray:
the **keyboard hook** — strictly more privileged, since it sees every keystroke
while the endpoint is authenticated and loopback-only — has always been a
checkbox. The endpoint was held to a stricter gate than the thing it is weaker
than.

Default stays off; making a switch findable is not flipping it. `--no-ui` reads
the setting and cannot change it, rather than growing a second mechanism for a
mode with no UI. A failed start reverts both the setting and the checkbox — a
checkbox reading "on" over a socket that never bound is the one state this must
not reach.

### Not Claude's alone

The implementation was already generic; the documentation was not. Auth is
`Authorization: Bearer`, the standard scheme; the transport is JSON-RPC over
POST returning `application/json`, a valid Streamable HTTP subset. Only the
**bridge** (for clients that can only spawn a subprocess) and the **skill** (a
Claude Skills artifact whose content is plain Markdown) are Claude-specific.

`doc/mcp.md` is now *Authoring actions with an AI agent*, with a table of who
has actually been tried. **It has one verified row.** Claude Code and
everything else are marked untried rather than supported — an honest empty
column is an invitation where a confident list would be a claim.

### The bug that exposed

Streamable HTTP requires a server offering no SSE stream to decline `GET` with
**405**. Having no `do_GET`, we returned the stdlib's default **501** — *this
server does not implement HTTP* — which a client that opens the optional server
stream before its first tool call can read as fatal. The bridge never sends
GET, so nothing had ever hit it; it only bites the clients this PR is inviting.
`DELETE` gets the same treatment.

### Labelling

"MCP Server" names a protocol, not a purpose — a row most users can neither
want nor avoid, which is not the visible switch this PR argues for. The menu
nests it under **AI Integration**; the console folds the category into the
checkbox's own label, because a checkbox draws its box left and label right, so
a separate `AI Integration:` landed *between* the two checkboxes and read as a
third peer. Measured through `resolve()`: the two checkboxes sat 0.25 base
units apart on the shared gap; a fixed spacer puts them at 3.50.

### Checks

- 365 passed, 16 skipped; `make api-reference-check` clean
- Console has no test coverage, so the toolbar row, the toggle handler
  (including the failed-start revert), the tray submenu nesting and the
  checkmark predicate were exercised directly
- Verified on a live macOS run — see the console screenshot in the thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)