### PR TITLE
Make the setup guide a URL you hand over, and ship the skill zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ VENV_STAMP := $(VENV)/.installed
 .PHONY: help venv install install-puikit check-venv test run run-debug run-sandbox echo icons icons-check \
         api-reference api-reference-check skill-bundle \
         clean clean-venv clean-macos clean-windows clean-windows-cache \
-        tag release-github release-whl release-status build publish-testpypi \
+        tag release-github release-whl release-skill release-status build publish-testpypi \
         macos-app macos-dmg install-macos-dmg uninstall-macos-dmg release-macos-dmg \
         windows-app windows-zip install-windows-zip uninstall-windows-zip release-windows-zip \
         windows-msix install-windows-msix uninstall-windows-msix release-windows-msix
@@ -105,6 +105,7 @@ help:
 	@echo "  make tag VERSION=x.y.z - bump __version__, commit, tag, push (no publishing)"
 	@echo "  make release-github    - open the GitHub Release at that tag"
 	@echo "  make release-whl       - upload sdist + wheel to PyPI, and to the Release"
+	@echo "  make release-skill     - attach the AI authoring skill bundle to the Release"
 	@echo "  make release-macos-dmg   - (on macOS)   attach Keyhac-<ver>-macos.dmg"
 	@echo "  make release-windows-zip - (on Windows) attach Keyhac-<ver>-win64.zip"
 	@echo "  make release-windows-msix - (on Windows) submit the MSIX to the Microsoft Store"
@@ -409,6 +410,17 @@ release-whl: $(PYPI_SDIST)
 	$(VENV_PYTHON) -m twine upload "$(PYPI_SDIST)" "$(PYPI_WHEEL)"
 	gh release upload v$(KEYHAC_VERSION) "$(PYPI_SDIST)" "$(PYPI_WHEEL)" --clobber
 	@echo "Published $(KEYHAC_VERSION) to PyPI and attached both distributions to release v$(KEYHAC_VERSION)"
+
+# --- release-skill: the authoring skill, where a user can reach it -----------
+# `make skill-bundle` needs the Makefile and tools/, and neither ships: the
+# sdist prunes tools and the wheel names its packages explicitly. So without
+# this target the only people who can obtain the bundle are the people who
+# already have the repository, and doc/ai-integration.md would be describing a
+# developer step as if it were the user's download.
+release-skill: skill-bundle
+	@$(call check_release_exists)
+	gh release upload v$(KEYHAC_VERSION) "dist/keyhac-action-authoring-skill.zip" --clobber
+	@echo "Attached the authoring skill to release v$(KEYHAC_VERSION)"
 
 # --- release-status: read-only progress check -------------------------------
 # The one place to see which artifacts have landed for the version the

--- a/doc/action_api.md
+++ b/doc/action_api.md
@@ -15,7 +15,7 @@ skill in `keyhac/skills/keyhac-action-authoring/` is the procedural half, and
 > unsettled part is `UINode` itself — how an element is identified, and how
 > long a node you are holding stays valid — which is the shape everything
 > below is built on. The rest of Keyhac's API is not affected; see
-> [Authoring actions with an AI agent](mcp.md) for what this covers and what it
+> [AI Integration](ai-integration.md) for what this covers and what it
 > would take to settle it.
 
 **Cross-platform by shape, not by data.** Every method here exists and behaves

--- a/doc/ai-integration.md
+++ b/doc/ai-integration.md
@@ -1,15 +1,26 @@
-# Authoring actions with an AI agent
+# AI Integration
+
+> ## Give this page's URL to your AI agent
+>
+> Ask it to set up Keyhac's skill and MCP server, and it can do most of it
+> from here — it will read [Setting it up](#setting-it-up) below, which is
+> written for it, and ask you for the parts only you can do. You do not have
+> to follow these instructions yourself.
+>
+> Keyhac's tray menu has the link: **AI Integration → Setup Guide**, pinned to
+> the version you are running.
 
 Keyhac can expose its element tools over MCP, so you can ask for an action in a
 chat window and have the agent inspect the actual screen, write it, run it,
 read the error, and fix it — instead of guessing at selectors and handing you
-code to debug.
+code to debug. The action it writes is plain Python on a key binding: no model
+runs when you later press the key.
 
 MCP is an open protocol and nothing here is specific to one vendor: Keyhac
 serves ordinary JSON-RPC over loopback HTTP with a bearer token, which is a
 plain Streamable HTTP endpoint. Any client that can reach one should work.
-[Connecting an agent](#connecting-an-agent) lists which have actually been
-tried, which is a shorter list.
+[Which clients have been tried](#which-clients-have-been-tried) is a shorter
+list.
 
 **This is off unless you turn it on**, and it is worth understanding why before
 you do: the endpoint reads the accessibility tree of every application you have
@@ -51,63 +62,79 @@ governs the keyboard hook, which has always been a checkbox rather than a
 setting. *(2.2.0 had a `keymap.enable_mcp_server()` call for this. It is gone —
 delete the line from your `config.py` and use the switch.)*
 
-## Connecting an agent
+## Setting it up
+
+**This section is addressed to the AI agent.** If you are a person reading it,
+you can follow it too — but handing the URL over is the shorter path.
+
+There are **two installs, and neither implies the other**. Getting one without
+the other is the common failure, and the halves fail very differently: with the
+skill and no connection, you will correctly say you cannot see the user's
+screen, which looks like the feature being broken. With the connection and no
+skill, everything appears to work and you will write actions containing `sleep`
+and screen coordinates, which break on a different machine.
+
+How your host installs an MCP server or a skill is **your** knowledge, and this
+page deliberately does not guess at it. What follows is only what Keyhac knows
+and you cannot.
+
+### 1. The skill
+
+Download `keyhac-action-authoring-skill.zip` from the Keyhac release matching
+the running version — the tag is in the URL you fetched this page from:
+
+```
+https://github.com/crftwr/keyhac/releases/tag/v<version>
+```
+
+Install it however this host takes a skill. It documents *that version's* API,
+so a mismatch is worth mentioning to the user rather than working around.
+
+### 2. The connection
+
+Ask the user to switch the endpoint on first: **AI Integration → MCP Server**
+in Keyhac's tray menu, or the **AI Integration** checkbox in its console
+window. It is off by default and you cannot turn it on yourself.
+
+Then:
+
+- Keyhac publishes the connection details as `mcp.json` beside the user's
+  `config.py` — `~/.keyhac/mcp.json` unless Keyhac's console reported a
+  different config directory at startup.
+- That file holds a `port` and a `token`. The endpoint is
+  `http://127.0.0.1:<port>/`, one JSON-RPC request per POST, and every request
+  needs an `Authorization: Bearer <token>` header.
+- **The port changes every time Keyhac restarts.** Point the client at the file
+  if it can read one. If it can only take a fixed value, say so — that is a
+  real limitation, not something to work around by pinning today's port.
+- If this host can only launch an MCP server as a subprocess over stdio, use
+  the command `keyhac-mcp-bridge` instead of the HTTP endpoint. It takes no
+  arguments and finds that file itself. A GUI client usually needs its absolute
+  path, since it does not inherit a shell `PATH`.
+
+### 3. How to go about it
+
+- **Back up** any other application's config file before editing it, and show
+  the user the change.
+- **Do not quit or restart another application.** Ask, and say what they should
+  see afterwards.
+- **Verify rather than assume.** Once the client is restarted, call
+  `list_windows`. If the user's own windows come back, it worked. If the tool
+  is not there, say so plainly instead of guessing at the cause — and if you
+  are unsure of this host's config path or schema, ask rather than writing a
+  plausible one.
+- Anything you cannot do from here, ask the user for. Most of it you can.
+
+## Which clients have been tried
 
 | Client | Transport | Status |
 |---|---|---|
-| Claude Desktop | stdio → the bridge below | **Verified** — the actions in `examples/actions/` were authored through it |
+| Claude Desktop | stdio → [the bridge](#the-bridge-for-stdio-only-clients) | **Verified** — the actions in `examples/actions/` were authored through it |
 | Claude Code | HTTP directly (`claude mcp add --transport http`) | Should work, **untried** |
 | Anything else with MCP support | HTTP directly | Should work, **untried** |
 
 "Untried" is not scepticism about those clients — nobody has run them against
 this endpoint yet. If you do, whether it worked or not is the useful report.
-
-### Let the agent connect itself
-
-Every client installs MCP servers differently, and the agent running inside
-yours knows how its own host does it — far better than this page can, and for
-clients that did not exist when this page was written. So rather than a
-procedure per client, here is the half only Keyhac knows. Turn the switch on
-first, then paste this:
-
-> Set up Keyhac's MCP server for yourself, using whatever mechanism this client
-> uses to install MCP servers — you know that part, and the notes below
-> deliberately do not cover it.
->
-> What you cannot guess, so please don't:
->
-> - Keyhac is running with its MCP switch on. It publishes the connection
->   details as `mcp.json` beside my `config.py` — `~/.keyhac/mcp.json` unless
->   Keyhac's console reported a different config directory at startup.
-> - That file holds a `port` and a `token`. The endpoint is
->   `http://127.0.0.1:<port>/`, one JSON-RPC request per POST, and every
->   request needs an `Authorization: Bearer <token>` header.
-> - **The port changes every time Keyhac restarts.** Point the client at the
->   file if it can read one. If it can only take a fixed value, tell me that
->   rather than pinning today's port — it is a real limitation, not something
->   to work around.
-> - If this client can only launch an MCP server as a subprocess over stdio,
->   use the command `keyhac-mcp-bridge` instead of the HTTP endpoint. It takes
->   no arguments and finds that file itself. A GUI client usually needs its
->   absolute path, since it does not inherit a shell `PATH`.
->
-> How I would like you to go about it:
->
-> - Back up any other application's config file before editing it, and show me
->   the change.
-> - Do not quit or restart another application yourself. Tell me to, and tell
->   me what I should see afterwards.
-> - Once I have restarted it, verify by calling `list_windows` — if my open
->   windows come back, it worked. If the tool is not there, say so plainly
->   instead of guessing at the cause.
-> - Finally, check whether the authoring skill is installed as well. It is a
->   separate install, and having the tools without it is the quiet failure:
->   you will be able to see my screen and will write actions containing
->   `sleep` and screen coordinates.
-
-The last point is the one worth keeping even if you install by hand. Neither
-half implies the other, and the two ways of getting it half-done fail very
-differently — see [the skill is not the connection](#add-the-authoring-skill).
 
 **Connecting over HTTP directly**, for a client that can: the port and token
 are published in `mcp.json` beside your `config.py`, the endpoint is
@@ -160,27 +187,30 @@ write an action — the rules that stop it emitting `sleep`, coordinates, and
 unverified writes. Without it you will get plausible code that breaks on a
 slower machine.
 
-Skills are a Claude feature, so the packaged bundle is for Claude Desktop.
-The content is not: `keyhac/skills/keyhac-action-authoring/` is Markdown, and any
-agent that can be given documents can be given these. What it cannot be given
-is the *habit* of consulting them unprompted, which is the part a skill buys.
-
-Claude Desktop → Settings → カスタマイズ / Customize → Skills → Add → **Upload
-skill**, and give it the bundle:
+**Get it from the release**, as `keyhac-action-authoring-skill.zip`:
 
 ```
-make skill-bundle        # writes dist/keyhac-action-authoring-skill.zip
+https://github.com/crftwr/keyhac/releases/tag/v<your version>
 ```
 
-The uploader states two requirements, and the bundle is built to meet both:
-the archive must contain a `SKILL.md` **at its root** (not nested in a folder),
-and that file must carry its name and description as YAML frontmatter. Uploads
-go through a security scan that takes a minute or two before the skill becomes
-usable.
+Match the version you are running — Keyhac's console prints it at startup, and
+the release for it is the one whose API the skill describes. The bundle carries
+that version stamped inside, so a mismatch is visible after the fact rather
+than silent.
 
-The skill documents *this version's* API, so re-upload it after upgrading
-Keyhac — `make skill-bundle` stamps the version into the bundle so a mismatch
-is visible.
+Skills are a Claude feature, so the packaged bundle is shaped for Claude
+Desktop: Settings → カスタマイズ / Customize → Skills → Add → **Upload skill**.
+The uploader states two requirements and the bundle meets both — a `SKILL.md`
+at the archive root, carrying its name and description as YAML frontmatter.
+Uploads go through a security scan that takes a minute or two.
+
+The *content* is not Claude-specific. Unzipped it is Markdown, and any agent
+that can be handed documents can be handed these. What that does not buy is the
+*habit* of consulting them unprompted, which is the part a skill mechanism
+provides.
+
+(Building it from a source checkout, if you are working on Keyhac itself:
+`make skill-bundle` writes the same zip into `dist/`.)
 
 **The skill is not the connection, and neither step implies the other.** The
 skill is knowledge — writing rules and an API reference, with no way to reach

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -343,7 +343,7 @@ surface, and `keyhac/skills/keyhac-action-authoring/` for how to write one.
 change in ways a minor release normally would not, and an upgrade may require
 editing actions you have written. Everything else here — key tables, clipboard
 history, macros, window control — keeps the stability you expect from a 2.x
-release. [Authoring actions with an AI agent](mcp.md) says what is unsettled and
+release. [AI Integration](ai-integration.md) says what is unsettled and
 what would settle it.
 
 ## Keyboard macros

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -1054,7 +1054,7 @@ Against the layers in §5 and the sequence in §10:
 | Layer 3 — execution safety | **Partial.** Waiting and read-back are in; per-step preconditions, checkpointing and idempotency are *patterns the actions follow*, not framework. `Action.preconditions()`, dry-run/preview, `Esc` cancellation and the long-action executor are **not built** — the `max_workers=1` pool is still the latent bug §2.1 names. |
 | Layer 4 — action metadata | **Minimal.** `keymap.register_action(name, action)` and the MCP tool schemas; no argument schema, no description surface. |
 | Layer 5 — artifact management | **Not built.** No `~/.keyhac/actions/*.py` discovery, no partial reload, no tool that writes Python to disk. Generated actions are pasted in by hand. |
-| Topology A — MCP | **Done.** `keyhac/mcp/`: nine tools over loopback HTTP with a per-start token, off unless the config asks; `keyhac-mcp-bridge` for Claude Desktop. See `doc/mcp.md`. |
+| Topology A — MCP | **Done.** `keyhac/mcp/`: nine tools over loopback HTTP with a per-start token, off unless the config asks; `keyhac-mcp-bridge` for Claude Desktop. See `doc/ai-integration.md`. |
 | Topology B — agent host | **Not built, and probably unnecessary** (§3.4). Nothing has needed runtime inference. |
 | `LLMAction` | **Still undecided, and the evidence is in.** Six actions, none needed inference. §3.4 said decide after hand-writing; the honest next step is deleting it. |
 
@@ -1068,7 +1068,7 @@ had not written the skill, against the operator's own screen:
    of importable names that was missing two of them. Fixed in the skill.
 2. *Save a set of pages as PDFs through Chrome's print dialog* — derived from a
    Claude Desktop **screen recording**, and the densest case in §2. The
-   recording/selector split in `doc/mcp.md` held: no pixel addressing survived
+   recording/selector split in `doc/ai-integration.md` held: no pixel addressing survived
    into the action, and its selectors are real AppKit identifiers read from the
    live tree.
 
@@ -1094,7 +1094,7 @@ Getting a working setup took: enable the server in `config.py`, reload, find
 the bridge's absolute path, write `mcpServers` into
 `claude_desktop_config.json`, fully quit and reopen Claude Desktop, run
 `make skill-bundle`, delete the previous skill, upload, wait for the security
-scan. Nine steps across three applications, and `doc/mcp.md` describes all of
+scan. Nine steps across three applications, and `doc/ai-integration.md` describes all of
 them correctly.
 
 It still went wrong, because **the skill and the bridge are independent
@@ -1103,7 +1103,7 @@ one.** With the skill uploaded and no bridge registered, Claude correctly
 reports that it is knowledge with no execution environment and cannot see your
 windows — which reads exactly like the feature not working. The reverse is
 quieter and worse: tools without the skill work, and return actions full of
-`sleep` and screen coordinates. `doc/mcp.md` now says so explicitly, which
+`sleep` and screen coordinates. `doc/ai-integration.md` now says so explicitly, which
 helps a reader and does nothing for the several remaining ways to get this
 half-done.
 
@@ -1116,7 +1116,7 @@ mechanical and was in fact done that way in the session that found the problem.
 blocking question, and it dissolves once you notice the agent already knows
 that half: it is running inside the client, and how that client installs an MCP
 server is exactly the kind of thing it knows better than a page written before
-that client existed. So `doc/mcp.md` carries a **prompt**, not a procedure, and
+that client existed. So `doc/ai-integration.md` carries a **prompt**, not a procedure, and
 the prompt covers only what Keyhac knows and the agent cannot guess — that the
 port and token are in `mcp.json` beside `config.py`, that **the port changes
 every restart** so the file is the thing to point at, that auth is a bearer
@@ -1139,7 +1139,7 @@ application's config, and never quit or restart one — say what to expect
 instead. And the circularity is weaker than it looked. An agent cannot verify
 *before* the install, but it does not need to: the user restarts the client and
 the agent's first tool call settles it. That also decides where this lives —
-`doc/mcp.md`, because a user with no connection is a user with no skill either,
+`doc/ai-integration.md`, because a user with no connection is a user with no skill either,
 so the skill is the one place it certainly cannot be.
 
 Still unwritten: nobody has run this prompt. It is the same "untried" as the
@@ -1151,7 +1151,7 @@ than Claude Desktop is the useful report.
 f6cf4e0 gave the skill the file header, the `extensions/` placement and the
 `configure()` registration block, so a generated action now says where it goes.
 What it does not address: **no tool writes Python to disk, deliberately** (§4.4
-and `doc/mcp.md`), so the operator is the transport. They paste a class into
+and `doc/ai-integration.md`), so the operator is the transport. They paste a class into
 `~/.keyhac/extensions/`, then paste three more lines into the middle of a
 config file that is theirs, several hundred lines long, and already working.
 

--- a/keyhac/mcp/__init__.py
+++ b/keyhac/mcp/__init__.py
@@ -2,6 +2,6 @@
 
 `server.py` serves them over localhost HTTP from inside the daemon, `tools.py`
 defines them, and `bridge.py` is the stdio shim for clients that spawn a
-subprocess. See doc/mcp.md, and doc/dev/ai-integration.md §4 for why the split
+subprocess. See doc/ai-integration.md, and doc/dev/ai-integration.md §4 for why the split
 is shaped this way.
 """

--- a/keyhac/platform/base.py
+++ b/keyhac/platform/base.py
@@ -224,6 +224,10 @@ class AppControl(ABC):
         application (a name or path meaningful to the OS); None picks a
         platform default.  Failure is logged, not raised."""
 
+    @abstractmethod
+    def open_url(self, url: str) -> None:
+        """Open a URL in the user's default browser.  Logged, not raised."""
+
 
 class Window(ABC):
     """A top-level OS window.

--- a/keyhac/platform/mac/apps.py
+++ b/keyhac/platform/mac/apps.py
@@ -54,6 +54,13 @@ class MacAppControl(AppControl):
     def launch(self, app_name: str) -> None:
         subprocess.Popen(["open", "-a", app_name])
 
+    def open_url(self, url: str) -> None:
+        # No -a: LaunchServices picks the default browser for the scheme.
+        try:
+            subprocess.Popen(["open", url])
+        except OSError as e:
+            logger.warning(f"Could not open {url}: {e}")
+
     def edit_file(self, path: str, editor: str | None = None) -> None:
         """``open -a`` the file in the editor, or in the first installed
         fallback.  Each attempt blocks until LaunchServices accepts or

--- a/keyhac/platform/win/apps.py
+++ b/keyhac/platform/win/apps.py
@@ -71,6 +71,17 @@ class WinAppControl(AppControl):
     def launch(self, app_name: str) -> None:
         os.startfile(app_name)
 
+    def open_url(self, url: str) -> None:
+        # startfile on a URL is ShellExecute "open", which is what the shell
+        # does for a link: the registered handler for the scheme, not a browser
+        # we picked.
+        if sys.platform != "win32":
+            return
+        try:
+            os.startfile(url)
+        except OSError as e:
+            logger.warning(f"Could not open {url}: {e}")
+
     def edit_file(self, path: str, editor: str | None = None) -> None:
         """ShellExecute the editor with the quoted path (the keyhac-win
         editTextFile call: PATH and App Paths both resolve the name, so

--- a/keyhac/ui/tray.py
+++ b/keyhac/ui/tray.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 from puikit import Menu, MenuItem, SEPARATOR
 
+from keyhac.core import log
+
+logger = log.getLogger("Tray")
+
 _ASSETS = Path(__file__).with_name("assets")
 
 
@@ -33,6 +37,18 @@ def install_tray(console, keymap, hook) -> None:
         console._hook_checkbox.checked = hook.installed
         console.panel.render()
 
+    def open_guide():
+        # Pinned to the running version, not main: the page tells an agent
+        # which skill bundle to fetch and what this build's API looks like, and
+        # main would hand it a newer answer than the Keyhac it is talking to.
+        import keyhac
+        url = (f"https://github.com/crftwr/keyhac/blob/v{keyhac.__version__}"
+               f"/doc/ai-integration.md")
+        if keymap.app_control is None:
+            logger.info(f"AI integration guide: {url}")
+            return
+        keymap.app_control.open_url(url)
+
     def toggle_mcp():
         # Through the console's handler rather than the keymap's, so the
         # setting is written and the checkbox follows from one place - the two
@@ -55,6 +71,11 @@ def install_tray(console, keymap, hook) -> None:
         MenuItem("AI Integration", submenu=Menu(
             MenuItem("MCP Server", on_select=toggle_mcp,
                      checked=lambda: keymap.mcp_server_running),
+            SEPARATOR,
+            # The setup instructions are the thing you hand to an agent, so
+            # what this really provides is the URL - the page's first line
+            # tells the reader to pass it on rather than follow it themselves.
+            MenuItem("Setup Guide", on_select=open_guide),
         )),
         SEPARATOR,
         MenuItem("Quit Keyhac", on_select=console.backend.quit),

--- a/tools/generate_api_reference.py
+++ b/tools/generate_api_reference.py
@@ -131,7 +131,7 @@ skill in `keyhac/skills/keyhac-action-authoring/` is the procedural half, and
 > unsettled part is `UINode` itself — how an element is identified, and how
 > long a node you are holding stays valid — which is the shape everything
 > below is built on. The rest of Keyhac's API is not affected; see
-> [Authoring actions with an AI agent](mcp.md) for what this covers and what it
+> [AI Integration](ai-integration.md) for what this covers and what it
 > would take to settle it.
 
 **Cross-platform by shape, not by data.** Every method here exists and behaves


### PR DESCRIPTION
Three changes, one problem: **an end user could not obtain the authoring skill
at all.** `doc/mcp.md` said

```
make skill-bundle        # writes dist/keyhac-action-authoring-skill.zip
```

which is how *this repository* builds the bundle, not how anyone gets it. The
Makefile and `tools/` do not ship — the sdist prunes `tools`, the wheel names
its packages explicitly — so that instruction was reachable only by people who
already had everything. v2.2.0 carries a wheel, an sdist and a Windows zip, and
no skill. The one part of the setup the page insists you must not skip was the
one part it gave no way to complete.

### 1. `make release-skill`

Attaches the bundle to the GitHub Release, following `release-whl`'s shape:
build, guard that the Release exists, `gh release upload --clobber`. The page
now points at the release matching the running version, with `make
skill-bundle` demoted to a parenthetical for people working on Keyhac itself.

### 2. The prompt became the page

Rather than a block to copy-paste, the document **addresses the agent directly
and the user hands over its URL** — the agent can read GitHub, download an
asset, and ask for what it cannot do itself.

That is the "instruction document an agent executes" §15.1 originally wanted,
arrived at by *deleting* the intermediary rather than building one. The content
is unchanged: the two installs and how differently their half-done states fail,
`mcp.json` beside `config.py`, the port moving every restart, the bearer
header, the bridge for stdio-only hosts, and the guardrails — back up, do not
restart another application, verify with `list_windows` rather than assuming,
ask when unsure of this host's config path instead of writing a plausible one.

`doc/mcp.md` → **`doc/ai-integration.md`**: the page covers the skill, the
endpoint, the authoring loop and the recorded-demonstration path, and only one
of those is MCP. It now matches what the menu calls it.

### 3. Tray: **AI Integration → Setup Guide**

Opens that page pinned to `v{__version__}` rather than `main` — the page tells
an agent which skill bundle to fetch and what this build's API looks like, and
`main` would hand it a newer answer than the Keyhac it is talking to.

Reaching a browser needed `AppControl.open_url`, which is `edit_file`'s
neighbour and follows it: `open` with no `-a` on macOS so LaunchServices picks
the default handler, `os.startfile` on Windows, both logging rather than
raising. With no `app_control` wired the menu logs the URL, which is still the
useful half.

### Checks

- Menu item resolves to the pinned URL; degrades to a log line without `app_control`
- Both platform implementations satisfy the ABC — Windows compile-checked and
  AST-checked, not run here
- `make -n release-skill` shows the guard and the upload
- 365 passed, 16 skipped; api-reference regenerated

Not added to `README.md` — same reasoning as the experimental marker; the menu
is the discovery path now.

**Follow-up, not in this PR:** `release-skill` has not been run against v2.2.0.
Attaching now would upload today's `main` under that tag, which does not match
it — cleaner to let the next release carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)