### PR TITLE
Layer 3: Esc stops a running action, and one action stops blocking the rest

### DIFF
--- a/doc/action_api.md
+++ b/doc/action_api.md
@@ -27,7 +27,7 @@ screen that was inspected first, so it is not portable — the framework is.
 `UI.enable_content_access()` is the one deliberately one-sided call, exposed so
 an action can make it unconditionally.
 
-**Contents:** [UI](#class-ui) · [UINode](#class-uinode) · [WaitTimeout](#class-waittimeout) · [FillFailed](#class-fillfailed)
+**Contents:** [UI](#class-ui) · [UINode](#class-uinode) · [WaitTimeout](#class-waittimeout) · [FillFailed](#class-fillfailed) · [ActionCancelled](#class-actioncancelled)
 
 
 ## <kbd>class</kbd> `UI`
@@ -419,6 +419,26 @@ Deliberately its own type, and deliberately an error rather than a False return:
 A write did not take. 
 
 Carries what was attempted, because "the field is still empty" and "the field has the wrong text" want different responses from the caller. 
+
+---
+
+
+## <kbd>class</kbd> `ActionCancelled`
+Raised inside a running action when the user cancels it with Esc. 
+
+**Derived from BaseException rather than Exception, and that is the point.** An action of the kind this framework exists for catches `Exception` around each item, because partial failure is the thing it is built to survive: 
+
+```python
+for system in self.systems:
+     try:
+         self._read_system(system, rows)
+     except Exception as error:          # <- would swallow a cancellation
+         self.failed.append((system["name"], str(error)))
+``` 
+
+Were this an ordinary Exception, pressing Esc there would be recorded as "SystemA failed" and the run would carry on to SystemB - the one thing cancelling must not do. As a BaseException it passes through every such handler while still unwinding the action's `finally` blocks, so progress already written stays written. 
+
+Cancellation is KeyboardInterrupt's cousin, not an error. An action never needs to know this class exists: `wait_for` raises it, and long actions spend most of their time waiting. 
 
 ---
 

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -926,6 +926,30 @@ An action's most-used object, so it is one attribute away rather than two lines 
 
 ---
 
+### <kbd>method</kbd> `ThreadedAction.cancelled`
+
+```python
+cancelled() → bool
+```
+
+True once the user has asked this action to stop. 
+
+Check it in a loop that does not wait - `wait_for` already raises `ActionCancelled` on its own, and a loop built out of waits needs nothing else. 
+
+---
+
+### <kbd>method</kbd> `ThreadedAction.check_cancelled`
+
+```python
+check_cancelled() → None
+```
+
+Raise `ActionCancelled` if the user has asked this action to stop. 
+
+For a stretch of work with no wait in it - a long parse, a big write - where cancellation would otherwise not be noticed until the next wait. 
+
+---
+
 ### <kbd>method</kbd> `ThreadedAction.finished`
 
 ```python

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -426,16 +426,35 @@ precondition for eliminating runtime LLM calls.**
   writes, window moves and text insertion are genuinely reversible and can share an undo
   design with XeFM; writes already accepted by a remote system are not, and for the §2
   workload those dominate.
-- **Cancellation** — `Esc` must stop a long-running action
-- **A separate executor for long-running actions.** `ThreadedAction`'s `starting()` /
-  `run()` / `finished(result)` lifecycle is a good fit for single-shot transforms
-  (`starting()` is the right place to freeze origin; `finished()` the right place for
-  approval), but the pool is `max_workers=1` (`keyhac/core/action.py`), so one
-  minutes-long run blocks every other `ThreadedAction` in the app. That is a latent bug
-  today. The tens-of-minutes actions in §2 make fixing it a prerequisite, not a
-  nice-to-have. Whether the fix needs a full `AsyncAction` (resident event loop, task
-  handle, progress channel, mid-run approval) or just a second executor depends on
-  whether agent loops ever run at runtime — see §3.4.
+- ~~**Cancellation** — `Esc` must stop a long-running action~~ **Done.**
+  `ActionCancelled` derives from `BaseException`, which is the whole design: an
+  action of this class wraps each item in `except Exception` to survive partial
+  failure, and an ordinary exception would be filed there as "item 7 failed" and
+  the run would continue — the one thing cancelling must not do. `wait_for`
+  raises it at the top of each poll, so an action needs no line about it;
+  `check_cancelled()` covers a stretch with no wait in it. Only `kind == "real"`
+  cancels: Keyhac's own translated output never reaches `on_key_event` (the
+  platform layer drops it on its own tag) and replay is excluded on purpose, so
+  an action pressing Escape cannot kill itself and a macro cannot kill it either.
+  Esc is consumed only when it actually stopped something.
+- ~~**A separate executor for long-running actions.**~~ **Done, and it needed
+  neither a second pool nor an `AsyncAction`.** §3.4 killed the `AsyncAction`
+  branch (no runtime inference ever appeared), and the "second executor" branch
+  turned out to be answering the wrong question. `max_workers=1` was not what
+  kept concurrent actions safe: injected keystrokes are serialized by the engine
+  lock (`InputContext.__enter__` takes it) and AX access by
+  `call_on_main_thread`. The only thing the pool's shape protected was the
+  clipboard save/restore in `core/fill.py`, which now holds a reentrant lock of
+  its own — reentrant because `_paste` opens that context inside a caller that
+  already has. So the fix was to raise the worker count and lock the one
+  genuinely shared resource. **No `long_running` flag, and nothing for the skill
+  to teach**: a flag would have asked the author to classify work whose duration
+  they cannot know (`extract_records` is seconds against a fixture and tens of
+  minutes against a real system — same code), and getting it wrong would have
+  been silent.
+  *Cost:* two key bindings that used to queue can now overlap. Each `with ctx:`
+  batch stays atomic, so typing cannot interleave mid-batch, but two typing
+  actions started at once will interleave batches.
 - The output-side primitives these actions are built from — `wait_for`, form filling,
   pagination — are specified in §7.
 
@@ -1051,7 +1070,7 @@ Against the layers in §5 and the sequence in §10:
 |---|---|
 | Layer 1 — observation | Event subscription **dropped** after measuring (§5). Trace capture **not ours to build** — Claude Desktop records and narrates; §5 has the reasoning. |
 | Layer 2 — state reading | **Done**, both platforms. `keymap.ui` + `UINode`, the text layer, verified live on macOS and Windows. |
-| Layer 3 — execution safety | **Partial.** Waiting and read-back are in; per-step preconditions, checkpointing and idempotency are *patterns the actions follow*, not framework. `Action.preconditions()`, dry-run/preview, `Esc` cancellation and the long-action executor are **not built** — the `max_workers=1` pool is still the latent bug §2.1 names. |
+| Layer 3 — execution safety | **Partial, and less so.** Waiting, read-back, **`Esc` cancellation** and **the executor** are in; the `max_workers=1` bug §2.1 named is gone. Per-step preconditions, checkpointing and idempotency remain *patterns the actions follow*, not framework: `Action.preconditions()` and dry-run/preview are **not built**. |
 | Layer 4 — action metadata | **Minimal.** `keymap.register_action(name, action)` and the MCP tool schemas; no argument schema, no description surface. |
 | Layer 5 — artifact management | **Not built.** No `~/.keyhac/actions/*.py` discovery, no partial reload, no tool that writes Python to disk. Generated actions are pasted in by hand. |
 | Topology A — MCP | **Done.** `keyhac/mcp/`: nine tools over loopback HTTP with a per-start token, off unless the config asks; `keyhac-mcp-bridge` for Claude Desktop. See `doc/ai-integration.md`. |

--- a/keyhac/__init__.py
+++ b/keyhac/__init__.py
@@ -22,6 +22,7 @@ from keyhac.core.clipboard_history import ClipboardHistory
 from keyhac.core.uitree import UINode
 from keyhac.core.wait import WaitTimeout
 from keyhac.core.fill import FillFailed
+from keyhac.core.action import ActionCancelled
 from keyhac.actions import (
     ActivateWindow,
     MouseButtonClick,
@@ -59,6 +60,7 @@ __all__ = [
     "UINode",
     "WaitTimeout",
     "FillFailed",
+    "ActionCancelled",
     "ChooserAction",
     "MouseButtonClick",
     "MouseButtonDown",

--- a/keyhac/core/action.py
+++ b/keyhac/core/action.py
@@ -5,6 +5,8 @@ starting()/finished() run on the event-loop thread under the engine lock
 pool.
 """
 
+import contextlib
+import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -12,6 +14,47 @@ from typing import Any
 from keyhac.core import log
 
 logger = log.getLogger("Action")
+
+
+class ActionCancelled(BaseException):
+    """Raised inside a running action when the user cancels it with Esc.
+
+    **Derived from BaseException rather than Exception, and that is the
+    point.** An action of the kind this framework exists for catches
+    `Exception` around each item, because partial failure is the thing it is
+    built to survive:
+
+    ```python
+    for system in self.systems:
+        try:
+            self._read_system(system, rows)
+        except Exception as error:          # <- would swallow a cancellation
+            self.failed.append((system["name"], str(error)))
+    ```
+
+    Were this an ordinary Exception, pressing Esc there would be recorded as
+    "SystemA failed" and the run would carry on to SystemB - the one thing
+    cancelling must not do. As a BaseException it passes through every such
+    handler while still unwinding the action's `finally` blocks, so progress
+    already written stays written.
+
+    Cancellation is KeyboardInterrupt's cousin, not an error. An action never
+    needs to know this class exists: `wait_for` raises it, and long actions
+    spend most of their time waiting.
+    """
+
+
+#: The action whose run() this thread is executing.  How `wait_for` - a free
+#: function that is handed no action - knows whose cancellation to honour.
+_current = threading.local()
+
+
+def current_action():
+    """The ThreadedAction running on this thread, or None.
+
+    lazydocs: ignore
+    """
+    return getattr(_current, "action", None)
 
 
 class ThreadedAction:
@@ -43,7 +86,64 @@ class ThreadedAction:
     ```
     """
 
-    thread_pool = ThreadPoolExecutor(max_workers=1)
+    # More than one worker, so a run() that takes minutes stops holding up
+    # every other action in the application - the §2.1 bug that made a
+    # tens-of-minutes ETL action freeze an unrelated key binding.
+    #
+    # The single worker was never what kept concurrent actions safe, which is
+    # why raising it is not the hazard it looks like: injected keystrokes are
+    # serialized by the engine lock (InputContext.__enter__ takes it), and
+    # windows and AX elements are reachable only through
+    # call_on_main_thread, which serializes on the loop thread. The one thing
+    # the pool's shape *was* protecting is the clipboard save/restore in
+    # core/fill.py, and that now holds a lock of its own.
+    #
+    # What does change: two key bindings that used to queue can now overlap.
+    # Each `with ctx:` batch stays atomic, so typing cannot interleave mid-
+    # batch, but two typing actions started at once will interleave batches.
+    thread_pool = ThreadPoolExecutor(max_workers=None,
+                                     thread_name_prefix="keyhac-action")
+
+    #: Actions whose run() has not returned, so Esc can reach them.  A set
+    #: rather than one slot: nothing stops two long actions running now.
+    _running: set = set()
+    _running_lock = threading.Lock()
+
+    @classmethod
+    def cancel_all(cls) -> int:
+        """Ask every running action to stop.  Returns how many were asked.
+
+        Called from the keyboard hook, so it must stay O(1) in the number of
+        actions and do no I/O: setting an Event is the whole of it.
+
+        lazydocs: ignore
+        """
+        with cls._running_lock:
+            running = tuple(cls._running)
+        for action in running:
+            flag = getattr(action, "_cancel_flag", None)
+            if flag is not None:
+                flag.set()
+        return len(running)
+
+    def cancelled(self) -> bool:
+        """True once the user has asked this action to stop.
+
+        Check it in a loop that does not wait - `wait_for` already raises
+        `ActionCancelled` on its own, and a loop built out of waits needs
+        nothing else.
+        """
+        flag = getattr(self, "_cancel_flag", None)
+        return flag is not None and flag.is_set()
+
+    def check_cancelled(self) -> None:
+        """Raise `ActionCancelled` if the user has asked this action to stop.
+
+        For a stretch of work with no wait in it - a long parse, a big write -
+        where cancellation would otherwise not be noticed until the next wait.
+        """
+        if self.cancelled():
+            raise ActionCancelled(f"{self!r} was cancelled")
 
     @property
     def keymap(self):
@@ -70,8 +170,40 @@ class ThreadedAction:
         with keymap._lock:
             self.starting()
 
-        future = ThreadedAction.thread_pool.submit(self.run)
+        future = ThreadedAction.thread_pool.submit(self._run_tracked)
         future.add_done_callback(self._done_callback)
+
+    def _run_tracked(self):
+        with self.cancellable():
+            return self.run()
+
+    @contextlib.contextmanager
+    def cancellable(self):
+        """Make this action reachable by Esc for the duration of the block.
+
+        Both ways of starting an action enter this: `_run_tracked` for a key
+        press, and the MCP `run_action` tool, which drives the lifecycle
+        itself. Without it, an action started from a chat window would be the
+        one you could not stop.
+
+        The flag is built here rather than in `__init__` because subclasses
+        write their own and do not call `super()` - the documented shape, and
+        what all six examples do. Deregistration is here too rather than in
+        `_finish`, which is handed to the loop thread and may not have run
+        yet when the next Esc arrives.
+
+        lazydocs: ignore
+        """
+        self._cancel_flag = threading.Event()
+        _current.action = self
+        with ThreadedAction._running_lock:
+            ThreadedAction._running.add(self)
+        try:
+            yield self
+        finally:
+            _current.action = None
+            with ThreadedAction._running_lock:
+                ThreadedAction._running.discard(self)
 
     def _done_callback(self, future):
         # add_done_callback fires on the pool thread; hand finished() back to
@@ -87,6 +219,11 @@ class ThreadedAction:
             from keyhac.core.keymap import Keymap
             with Keymap.get_instance()._lock:
                 self.finished(result)
+        except ActionCancelled:
+            # Needs its own arm: BaseException would otherwise sail past the
+            # handler below and into the event loop.  finished() is skipped on
+            # purpose - it reports a result the action never produced.
+            logger.info(f"{self!r} cancelled.")
         except Exception:
             print()
             logger.error(f"Threaded action failed:\n{traceback.format_exc()}")

--- a/keyhac/core/fill.py
+++ b/keyhac/core/fill.py
@@ -44,6 +44,7 @@ the element half themselves.
 from __future__ import annotations
 
 import contextlib
+import threading
 import time
 from typing import Any, Iterable
 
@@ -98,6 +99,18 @@ def _keymap():
 
 # -- clipboard ---------------------------------------------------------------
 
+#: Held across the whole save/write/restore, because that sequence is the one
+#: shared resource the action pool's single worker used to protect for free.
+#: With more than one worker, two actions pasting at once would each save the
+#: other's scratch value and put it back as "what the user had".
+#:
+#: Reentrant, and not optionally: `_paste` opens this context itself, while
+#: the documented way to write several fields is to wrap the lot in one - so
+#: the nested case is the normal case, and a plain Lock would deadlock the
+#: example in the docstring below.
+_clipboard_lock = threading.RLock()
+
+
 @contextlib.contextmanager
 def preserve_clipboard():
     """Put the clipboard back the way it was.
@@ -113,22 +126,25 @@ def preserve_clipboard():
         set_text(field, "REC-001")
     ```
     """
-    keymap = _keymap()
-    clipboard = keymap.clipboard if keymap else None
-    saved = None
-    if clipboard is not None:
-        try:
-            saved = clipboard.get_text()
-        except Exception:
-            logger.debug("could not read the clipboard to save it", exc_info=True)
-    try:
-        yield
-    finally:
-        if clipboard is not None and saved is not None:
+    with _clipboard_lock:
+        keymap = _keymap()
+        clipboard = keymap.clipboard if keymap else None
+        saved = None
+        if clipboard is not None:
             try:
-                clipboard.set_text(saved)
+                saved = clipboard.get_text()
             except Exception:
-                logger.debug("could not restore the clipboard", exc_info=True)
+                logger.debug("could not read the clipboard to save it",
+                             exc_info=True)
+        try:
+            yield
+        finally:
+            if clipboard is not None and saved is not None:
+                try:
+                    clipboard.set_text(saved)
+                except Exception:
+                    logger.debug("could not restore the clipboard",
+                                 exc_info=True)
 
 
 # -- focus -------------------------------------------------------------------

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -20,6 +20,7 @@ from keyhac.core.key import KeyCondition, KeyTable
 from keyhac.core.focus import FocusCondition
 from keyhac.core.input import InputContext
 from keyhac.core import log
+from keyhac.core.action import ThreadedAction
 from keyhac.core.config import Config
 from keyhac.platform.base import InputHook, FocusProvider, Focus, KeyEvent
 
@@ -153,6 +154,9 @@ class Keymap:
             self._modifier = 0
             self.editor = ""
             self._vk_mod_map = dict(get_key_names().modifier_vk_map)
+            # Layout-dependent like every other vk, so it cannot outlive the
+            # init_key_names() above.
+            self._escape_vk_cached = None
 
             logger.info("Loading configuration script.")
 
@@ -438,11 +442,36 @@ class Keymap:
 
         lazydocs: ignore
         """
+        # Before the keytable, so Esc reaches a running action whether or not
+        # the active table binds it - and outside the engine lock, because
+        # this runs inside the hook's deadline and cancel_all() only sets an
+        # Event.
+        #
+        # kind == "real" is the whole of "physical, not ours". Output Keyhac
+        # injects in translated mode never reaches this callback at all (the
+        # platform layer drops it on its own tag), and "replay" is excluded
+        # here on purpose: a macro replaying an Esc must not kill an action
+        # the user is watching. What "real" does still include is another
+        # application's injected input, which the OS lets us distinguish but
+        # Keyhac does not - and an Esc from anywhere is a request to stop.
+        if event.down and event.kind == "real" and event.vk == self._escape_vk():
+            if ThreadedAction.cancel_all():
+                # Consumed only when it actually stopped something: swallowing
+                # every Esc would change what the focused application sees.
+                return True
+
         with self._lock:
             if event.down:
                 return bool(self._on_key_down(event.vk))
             else:
                 return bool(self._on_key_up(event.vk))
+
+    def _escape_vk(self) -> int:
+        """Esc's vk for the active layout, resolved once and remembered."""
+        vk = getattr(self, "_escape_vk_cached", None)
+        if vk is None:
+            vk = self._escape_vk_cached = get_key_names().str_to_vk("Escape")
+        return vk
 
     def on_hook_restored(self) -> None:
         """InputHook on_restored callback.

--- a/keyhac/core/wait.py
+++ b/keyhac/core/wait.py
@@ -43,6 +43,7 @@ import time
 from typing import Any, Callable
 
 from keyhac.core import log
+from keyhac.core.action import ActionCancelled, current_action
 from keyhac.core.uitree import UINode, find_element, get_ui_tree
 
 logger = log.getLogger("Wait")
@@ -169,6 +170,9 @@ def wait_for(condition: Callable[[], Any],
 
     Raises:
         WaitTimeout: The condition never became true.
+        ActionCancelled: The user pressed Esc.  Nothing has to catch this -
+            it unwinds through the action's `finally` blocks so progress
+            already recorded stays recorded.
         RuntimeError: Called on the event-loop thread, where blocking would
             hang the keyboard hook.
     """
@@ -177,6 +181,17 @@ def wait_for(condition: Callable[[], Any],
     gap = interval if interval is not None else MIN_INTERVAL
 
     while True:
+        # Here, at the top, rather than anywhere else in the loop: this is
+        # where control lands after each sleep, so cancelling costs at most
+        # one polling gap and never a whole condition evaluation. Waiting is
+        # where a long action spends nearly all of its time (§7.1), which is
+        # what makes one check in one function enough to make Esc work
+        # everywhere without an action containing a line about it.
+        action = current_action()
+        if action is not None and action.cancelled():
+            raise ActionCancelled(
+                f"cancelled while waiting for {message or 'a condition'}")
+
         result = evaluate_on_main_thread(condition)
         if result:
             return result

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -24,11 +24,13 @@ directly, or through the node methods, which dispatch themselves.
 
 from __future__ import annotations
 
+import contextlib
 import io
 import logging
 import traceback
 
 from keyhac.core import log
+from keyhac.core.action import ActionCancelled
 
 logger = log.getLogger("MCP")
 
@@ -327,19 +329,33 @@ class ToolRegistry:
         if action is None:
             raise KeyError(f"no action named {name!r}; call list_actions")
 
-        # Deliberately not through ThreadedAction.__call__: that submits to the
-        # single-worker pool, which would make this call queue behind whatever
-        # else is running and return before the action had done anything. The
-        # lifecycle is reproduced here instead - starting() and finished() on
-        # the loop thread where they belong, run() on this one.
+        # Still not through ThreadedAction.__call__, but for one reason now
+        # rather than two. The pool no longer serializes everything behind a
+        # single worker, so queueing is no longer the problem; what remains is
+        # that __call__ returns as soon as it has submitted, and this tool has
+        # to hand back what the action logged. Registering with _running is
+        # what matters, and is done explicitly below, so Esc reaches an action
+        # started from here exactly as it reaches one started from a key.
         with _captured_log() as captured:
             try:
                 if hasattr(action, "run"):
                     self.ui.on_main_thread(action.starting)
-                    result = action.run()
+                    # register_action is duck-typed - anything with run() is
+                    # accepted - so an action that is not a ThreadedAction
+                    # still runs here, just without being cancellable.
+                    track = getattr(action, "cancellable", contextlib.nullcontext)
+                    with track():
+                        result = action.run()
                     self.ui.on_main_thread(lambda: action.finished(result))
                 else:
                     self.ui.on_main_thread(action)
+            except ActionCancelled:
+                # Its own arm because it is a BaseException: the handler below
+                # would not see it, and it would leave through the HTTP layer
+                # as a server error rather than as the answer it is.
+                return (captured.getvalue()
+                        + f"\n{name} was cancelled with Esc. Whatever it "
+                          f"logged above is how far it got.")
             except Exception:                             # noqa: BLE001
                 return (captured.getvalue()
                         + "\nthe action raised:\n" + traceback.format_exc())

--- a/keyhac/skills/keyhac-action-authoring/references/api.md
+++ b/keyhac/skills/keyhac-action-authoring/references/api.md
@@ -7,7 +7,8 @@ reference is `doc/action_api.md`; this is the working subset.
 The whole import list, and there is nothing else to reach for:
 
 ```python
-from keyhac import ThreadedAction, WaitTimeout, FillFailed, UINode, getLogger
+from keyhac import (ThreadedAction, WaitTimeout, FillFailed, ActionCancelled,
+                    UINode, getLogger)
 
 logger = getLogger("MyAction")     # `logger` is NOT importable - make one
 ```
@@ -123,6 +124,29 @@ is for making several reads atomic against a moving UI, or for calling a
 platform element method this API does not wrap. `starting()` and `finished()`
 already run there; `run()` does not, and must not block it — waiting there
 raises rather than freezing the keyboard.
+
+## Cancellation
+
+The user can stop a running action by pressing **Esc**. You get this for free
+and should write nothing for it: `ui.wait` and every wait built on it raise
+`ActionCancelled` at the next poll, and a long action spends nearly all its
+time waiting.
+
+Two things to know, and only two:
+
+```python
+except Exception:          # fine - ActionCancelled passes straight through
+except BaseException:      # DON'T - this catches it and the action won't stop
+```
+
+`ActionCancelled` derives from `BaseException` precisely so the `except
+Exception` you write around each item — to survive one bad row without losing
+the rest — does not turn a cancellation into "item 7 failed, carrying on".
+Your `finally` blocks still run, so progress already written stays written.
+
+If a stretch of work has no wait in it at all (a long parse, a big file
+write), call `self.check_cancelled()` in the loop. Otherwise the cancellation
+is not noticed until the next wait.
 
 ## The one platform-specific call
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,237 @@
+"""Cancelling a running action with Esc (Layer 3).
+
+What is pinned here is the set of things that fail *silently* if they regress:
+a cancellation swallowed by an action's own `except Exception`, an Esc that
+Keyhac itself injected killing the action that injected it, and the clipboard
+save/restore racing now that more than one action can run at a time.
+"""
+
+import threading
+import time
+
+import pytest
+
+from keyhac.core.action import ActionCancelled, ThreadedAction, current_action
+from keyhac.core.wait import wait_for
+from keyhac.platform.base import KeyEvent
+
+
+# -- the exception's one job -------------------------------------------------
+
+def test_cancellation_survives_the_handler_every_action_writes():
+    """`extract_records` wraps each system in `except Exception` so one bad
+    system does not lose the others - the shape this whole class of action has.
+    An ordinary exception would be recorded there as "SystemA failed" and the
+    run would carry on to SystemB, which is precisely what cancelling must not
+    do."""
+    reached_second_system = False
+
+    def run():
+        nonlocal reached_second_system
+        for index in (0, 1):
+            try:
+                if index == 0:
+                    raise ActionCancelled("user pressed Esc")
+            except Exception:                             # noqa: BLE001
+                continue                                  # "record and go on"
+            reached_second_system = True
+
+    with pytest.raises(ActionCancelled):
+        run()
+    assert not reached_second_system, "the cancellation was swallowed"
+
+
+def test_it_is_not_an_exception():
+    assert issubclass(ActionCancelled, BaseException)
+    assert not issubclass(ActionCancelled, Exception)
+
+
+# -- wait_for is where an action notices -------------------------------------
+
+class Waiter(ThreadedAction):
+    """Waits forever, and records how it came out."""
+
+    def __init__(self):
+        self.outcome = None
+        self.cleaned_up = False
+        self.started = threading.Event()
+
+    def run(self):
+        try:
+            self.started.set()
+            wait_for(lambda: False, timeout=30, message="something",
+                     interval=0.01)
+        except ActionCancelled:
+            self.outcome = "cancelled"
+            raise
+        finally:
+            # The reason cancellation unwinds rather than kills the thread:
+            # progress already made has to be written down (§2.1).
+            self.cleaned_up = True
+
+
+def test_wait_for_raises_when_the_action_is_cancelled():
+    action = Waiter()
+
+    # cancellable() is entered *on the thread that will run run()*, because
+    # that is where it plants the thread-local wait_for consults. Both real
+    # callers do exactly this - _run_tracked is what the pool submits, and the
+    # MCP tool wraps its own run() call - so a test that enters it elsewhere
+    # is testing a shape nothing uses.
+    def worker():
+        with action.cancellable():
+            _swallow(action.run)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    # run() sets this after cancellable() has registered, so waiting on it
+    # removes the race with cancel_all below.
+    assert action.started.wait(5), "run() never started"
+    ThreadedAction.cancel_all()
+    thread.join(10)
+
+    assert not thread.is_alive(), "wait_for did not come back"
+    assert action.outcome == "cancelled"
+    assert action.cleaned_up, "finally did not run - progress would be lost"
+
+
+def _swallow(func):
+    try:
+        func()
+    except BaseException:                                 # noqa: BLE001
+        pass
+
+
+def test_wait_for_is_unaffected_outside_an_action():
+    """A bare wait_for - a test, a library caller - has no action to consult,
+    and must not trip over the thread-local being empty."""
+    assert current_action() is None
+    assert wait_for(lambda: "ready", timeout=1) == "ready"
+
+
+# -- the flag ----------------------------------------------------------------
+
+def test_cancel_all_reaches_only_running_actions():
+    action = Waiter()
+    assert action.cancelled() is False
+    assert ThreadedAction.cancel_all() == 0, "nothing is running"
+
+    with action.cancellable():
+        assert ThreadedAction.cancel_all() == 1
+        assert action.cancelled() is True
+
+    # Out of the block it is deregistered, so a later Esc does not find it.
+    assert ThreadedAction.cancel_all() == 0
+
+
+def test_check_cancelled_covers_a_stretch_with_no_wait_in_it():
+    action = Waiter()
+    with action.cancellable():
+        action.check_cancelled()                          # no-op while running
+        ThreadedAction.cancel_all()
+        with pytest.raises(ActionCancelled):
+            action.check_cancelled()
+
+
+# -- the key event -----------------------------------------------------------
+
+class Counter(ThreadedAction):
+    def run(self):
+        return None
+
+
+def _escape(engine):
+    from keyhac.core.vk import get_key_names
+    return get_key_names().str_to_vk("Escape")
+
+
+def test_only_physical_escape_cancels(engine):
+    """The requirement that made this worth a test: Keyhac injects Esc itself,
+    and an action that presses Escape to dismiss a dialog must not thereby kill
+    itself. Translated output never reaches on_key_event at all (the platform
+    layer drops it on its own tag), so what is checked here is the other half -
+    that replay-injected input is excluded too, since a macro replaying an Esc
+    is not a user asking to stop."""
+    e = engine(lambda keymap: None)
+    action = Waiter()
+    vk = _escape(e)
+
+    with action.cancellable():
+        assert e.keymap.on_key_event(KeyEvent(vk, True, "replay")) is not True
+        assert action.cancelled() is False, "a replayed Esc cancelled an action"
+
+        assert e.keymap.on_key_event(KeyEvent(vk, True, "real")) is True
+        assert action.cancelled() is True
+
+
+def test_escape_passes_through_when_nothing_is_running(engine):
+    """Swallowing every Esc would change what the focused application sees."""
+    e = engine(lambda keymap: None)
+    assert e.keymap.on_key_event(KeyEvent(_escape(e), True, "real")) is not True
+
+
+def test_escape_up_is_not_a_cancel(engine):
+    e = engine(lambda keymap: None)
+    action = Waiter()
+    with action.cancellable():
+        e.keymap.on_key_event(KeyEvent(_escape(e), False, "real"))
+        assert action.cancelled() is False
+
+
+# -- what raising the pool exposed -------------------------------------------
+
+def test_the_pool_no_longer_serializes_everything():
+    """The §2.1 bug: one long run() held the single worker, so an unrelated key
+    binding did nothing until it returned."""
+    assert ThreadedAction.thread_pool._max_workers > 1
+
+    started = threading.Barrier(2, timeout=10)
+
+    def occupy():
+        started.wait()
+        time.sleep(0.05)
+
+    first = ThreadedAction.thread_pool.submit(occupy)
+    second = ThreadedAction.thread_pool.submit(occupy)
+    # Would deadlock on the timeout with one worker: the second never starts.
+    first.result(timeout=10)
+    second.result(timeout=10)
+
+
+def test_preserve_clipboard_is_reentrant():
+    """`_paste` opens the context inside a caller that already opened it, which
+    is the documented way to write several fields. A plain Lock would deadlock
+    the example in preserve_clipboard's own docstring."""
+    from keyhac.core.fill import preserve_clipboard
+
+    with preserve_clipboard():
+        with preserve_clipboard():
+            pass
+
+
+def test_preserve_clipboard_serializes_across_threads():
+    """With one pool worker this was free. With several, two actions pasting at
+    once would each save the other's scratch value and put it back as "what the
+    user had"."""
+    from keyhac.core.fill import preserve_clipboard
+
+    overlaps = []
+    inside = threading.Lock()
+    depth = [0]
+
+    def paste():
+        with preserve_clipboard():
+            with inside:
+                depth[0] += 1
+                overlaps.append(depth[0])
+            time.sleep(0.02)
+            with inside:
+                depth[0] -= 1
+
+    threads = [threading.Thread(target=paste) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(10)
+
+    assert max(overlaps) == 1, f"two threads were inside at once: {overlaps}"

--- a/tools/generate_api_reference.py
+++ b/tools/generate_api_reference.py
@@ -112,6 +112,7 @@ ACTION_API_NAMES = [
     "UINode",
     "WaitTimeout",
     "FillFailed",
+    "ActionCancelled",
 ]
 
 ACTION_HEADER = """# Action API reference


### PR DESCRIPTION
Two of §5's five Layer 3 items. The design turned on a fact that had to be
measured rather than assumed.

## The executor — neither a second pool nor an `AsyncAction`

§5 left the shape open: *"whether the fix needs a full `AsyncAction` … or just
a second executor depends on whether agent loops ever run at runtime"*. §3.4
settled that half — no runtime inference ever appeared — so `AsyncAction` was
dead. The "second executor" half was answering the wrong question.

**`max_workers=1` was never what kept concurrent actions safe.** Injected
keystrokes are serialized by the engine lock (`InputContext.__enter__` takes
it); windows and AX elements are reachable only through `call_on_main_thread`.
The single worker was protecting exactly one thing: the clipboard save/restore
in `core/fill.py`.

So: raise the worker count, and lock that one resource. Reentrant, and not
optionally — `_paste` opens `preserve_clipboard` inside a caller that already
has one, which is the documented way to write several fields, so a plain `Lock`
would deadlock the example in its own docstring.

**No `long_running` flag, and nothing for the skill to teach.** A flag would
ask the author to classify work whose duration they cannot know
(`extract_records` is seconds against a fixture and tens of minutes against a
real system — same code), and getting it wrong would be silent. That is the
same objection that ruled out a `ThreadedAction` subclass; a flag reintroduces
it under another name.

**Cost, stated plainly:** two key bindings that used to queue can now overlap.
Each `with ctx:` batch stays atomic so typing cannot interleave mid-batch, but
two typing actions started at once will interleave batches.

## Cancellation, and why it is a `BaseException`

This is the design, not a detail. An action of this class wraps each item in
`except Exception`, because surviving partial failure is what it is *for*:

```python
except Exception as error:
    self.failed.append((system["name"], str(error)))
```

An ordinary exception would be filed there as "SystemA failed" and the run
would carry on to SystemB — the one thing cancelling must not do. As a
`BaseException` it passes through every such handler while still unwinding
`finally`, so progress already written stays written. Every generated action
writes that handler, because all six examples do; this makes writing it safe
without the author knowing why.

An action needs **no line** about cancellation: `wait_for` raises at the top of
each poll, and a long action spends nearly all its time waiting (§7.1).
`check_cancelled()` covers a stretch with no wait in it.

**Only `kind == "real"` cancels.** Keyhac's own translated output never reaches
`on_key_event` — the platform layer drops it on its own tag — so an action
pressing Escape to dismiss a dialog cannot kill itself. Replay is excluded too:
a macro replaying an Esc is not a user asking to stop. The check sits before
the keytable lookup and outside the engine lock, since it runs inside the
hook's deadline; `cancel_all()` only sets Events. Esc is consumed **only when
it actually stopped something**.

## Consolidation

The MCP `run_action` tool bypassed `ThreadedAction.__call__` for two reasons
and now has one. It enters the same `cancellable()` context the pool path does,
so an action started from a chat window is as stoppable as one started from a
key — while keeping its duck-typing, since `register_action` accepts anything
with `run()`.

## Checks

- 377 passed, 16 skipped — 12 new
- **Calibrated in both directions:** flipping `ActionCancelled` to `Exception`
  fails two of them
- Driven end to end through the real entry point as well, since the tests
  exercise `cancellable()` directly: a 100-page action cancelled mid-run kept
  its first page, skipped `finished()`, deregistered itself, and ignored the
  replayed Esc that preceded the physical one

Remaining in Layer 3: `preconditions()`, dry-run/preview, and the progress
journal — all three "framework-ise what the examples already do by hand".

🤖 Generated with [Claude Code](https://claude.com/claude-code)