### PR TITLE
A UINode is a snapshot, and now says so when it stops being one

### DIFF
--- a/doc/action_api.md
+++ b/doc/action_api.md
@@ -27,7 +27,7 @@ screen that was inspected first, so it is not portable — the framework is.
 `UI.enable_content_access()` is the one deliberately one-sided call, exposed so
 an action can make it unconditionally.
 
-**Contents:** [UI](#class-ui) · [UINode](#class-uinode) · [WaitTimeout](#class-waittimeout) · [FillFailed](#class-fillfailed) · [ActionCancelled](#class-actioncancelled)
+**Contents:** [UI](#class-ui) · [UINode](#class-uinode) · [WaitTimeout](#class-waittimeout) · [FillFailed](#class-fillfailed) · [ActionCancelled](#class-actioncancelled) · [StaleElement](#class-staleelement)
 
 
 ## <kbd>class</kbd> `UI`
@@ -439,6 +439,22 @@ for system in self.systems:
 Were this an ordinary Exception, pressing Esc there would be recorded as "SystemA failed" and the run would carry on to SystemB - the one thing cancelling must not do. As a BaseException it passes through every such handler while still unwinding the action's `finally` blocks, so progress already written stays written. 
 
 Cancellation is KeyboardInterrupt's cousin, not an error. An action never needs to know this class exists: `wait_for` raises it, and long actions spend most of their time waiting. 
+
+---
+
+
+## <kbd>class</kbd> `StaleElement`
+The element this node was read from no longer exists. 
+
+**A `UINode` is a snapshot.** It records what an element was when the tree was walked; the screen moves on and the node does not notice. That is the contract on purpose - a node that quietly re-read itself would hide exactly the change an action's preconditions exist to catch. 
+
+So the node has to say when it has gone stale, and say it in a way an action can act on. The distinction this exists for is the one §3.7 turns on: 
+
+
+- `StaleElement` - *the screen moved*. Re-find the element and carry on, or  stop and hand back to a human. The action is not wrong. 
+- `FillFailed` / an empty search - *the selector is wrong*. The action was  written against a screen that is not this one, and running it again will  fail the same way. 
+
+Before this existed both arrived as "element supports no press action", because a dead element reports no actions - true, and the least useful true thing to say. 
 
 ---
 

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -984,10 +984,45 @@ captures the mouse. **If the AI side fails entirely, the investment still stands
   time that client's first read returns. Windows therefore needs no equivalent
   of macOS's `set_manual_accessibility()` — it needs a retry, which `wait_for`
   already is.
-- **UI tree API shape** — worth settling before implementation, since it is the ceiling
-  on action expressiveness and changing it later breaks every action. Element identity
-  (path? ID? name?), handle lifetime (persistent or single-use), how far to unify Windows
-  and macOS.
+- ~~**UI tree API shape**~~ — **settled, in three separate ways.** This was the
+  question the experimental marker was really about: it is the ceiling on action
+  expressiveness, and changing it later breaks every action.
+
+  *How far to unify Windows and macOS* was closed by §10 step 4 — at the API, as
+  far as it already goes; at the action, not at all.
+
+  *Element identity* was closed by practice rather than by decision, and only
+  the writing-down was missing. Address by `identifier` (DOM id / AXIdentifier /
+  AutomationId) where there is one, since it survives relabelling and
+  localisation (§6.1), then by role plus name or text — with the limit §10 step
+  4 found, that a DOM id reaches controls, tables and landmarks but not a plain
+  `<span>`. The framework's own `identity_key()` is a different thing entirely:
+  the raw platform ref, used by exactly one caller for the DAG dedupe in
+  `get_ui_tree`, and not public shape.
+
+  *Handle lifetime* is **snapshot**, now stated as a contract rather than only
+  in a docstring. A `UINode` records what an element was; the screen moves on
+  and the node does not notice; `reread()` refreshes one deliberately. The
+  alternative — nodes that quietly re-read themselves — was rejected because it
+  hides exactly the change §3.7's preconditions exist to catch, and because the
+  three-beat pattern in §7.2 already re-finds rather than re-uses.
+
+  Blessing it needed one gap filled first, and it turned out to be a bug rather
+  than a design hole. A dead element reports no actions, so `press()` on a
+  closed dialog's button raised `FillFailed("element supports no press
+  action")` — true, and the least useful true thing to say, since it points the
+  operator at their selector when the screen had simply moved. Worse on macOS,
+  where `perform_action` discarded the AXError entirely. So: `StaleElement`
+  beside `WaitTimeout` / `FillFailed` / `ActionCancelled`, `is_stale()` on both
+  platform elements (a fact; the policy stays in core), and `perform_action`
+  returning a bool on macOS as it already did on Windows. The distinction the
+  type buys is §3.7's: *the screen moved* is re-findable, *the selector is
+  wrong* is regenerate-the-action.
+
+  What is **not** closed, and is a smaller question: the Windows `is_stale()`
+  was written on macOS against the header and has not been run. `tools/uia_pass.py`
+  is where that gets settled; the vtable slot it uses is already pinned live,
+  so what is unverified is the HRESULT comparison rather than the call.
 - **Real AX/UIA tree size and retrieval cost** — measure on Electron apps, VSCode,
   browsers. Sets the default depth and filter.
 - **MCP sampling is a bonus, not a dependency.** Topology A as described — a chat

--- a/keyhac/__init__.py
+++ b/keyhac/__init__.py
@@ -19,7 +19,7 @@ from keyhac.core.clipboard_history import ClipboardHistory
 # The action API is reached through keymap.ui and UINode's own methods (see
 # doc/action_api.md); only the node type and the two exceptions an action has
 # to be able to catch are named here.
-from keyhac.core.uitree import UINode
+from keyhac.core.uitree import StaleElement, UINode
 from keyhac.core.wait import WaitTimeout
 from keyhac.core.fill import FillFailed
 from keyhac.core.action import ActionCancelled
@@ -61,6 +61,7 @@ __all__ = [
     "WaitTimeout",
     "FillFailed",
     "ActionCancelled",
+    "StaleElement",
     "ChooserAction",
     "MouseButtonClick",
     "MouseButtonDown",

--- a/keyhac/core/fill.py
+++ b/keyhac/core/fill.py
@@ -49,7 +49,7 @@ import time
 from typing import Any, Iterable
 
 from keyhac.core import log
-from keyhac.core.uitree import UINode
+from keyhac.core.uitree import StaleElement, UINode
 from keyhac.core.wait import WaitTimeout, evaluate_on_main_thread, wait_for
 
 logger = log.getLogger("Fill")
@@ -376,9 +376,28 @@ def _press(element) -> None:
     names = element.get_action_names() or []
     for name in ("AXPress", "Invoke", "Toggle", "AXConfirm", "Select"):
         if name in names:
-            element.perform_action(name)
+            if element.perform_action(name) is False:
+                _raise_if_stale(element, f"{name} was refused")
+                raise FillFailed(f"the element refused {name}")
             return
+    # A dead element reports no actions, so this is where the two arrive at the
+    # same place - and they need different answers. Ask before blaming the
+    # selector: "supports no press action" sent an operator looking at their
+    # action when the dialog had simply closed underneath it.
+    _raise_if_stale(element, "it went away before it could be pressed")
     raise FillFailed(f"element supports no press action (has {names})")
+
+
+def _raise_if_stale(element, what: str) -> None:
+    """Turn the platform's "this element is gone" into the typed error.
+
+    Policy lives here rather than in the platform layer, which only answers
+    the question. `getattr` because register_action and the tests both accept
+    duck-typed elements that predate `is_stale`.
+    """
+    probe = getattr(element, "is_stale", None)
+    if probe is not None and probe():
+        raise StaleElement(f"the element is no longer on screen: {what}")
 
 
 def press(target) -> None:

--- a/keyhac/core/uitree.py
+++ b/keyhac/core/uitree.py
@@ -40,6 +40,30 @@ import fnmatch
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator
 
+
+class StaleElement(Exception):
+    """The element this node was read from no longer exists.
+
+    **A `UINode` is a snapshot.** It records what an element was when the tree
+    was walked; the screen moves on and the node does not notice. That is the
+    contract on purpose - a node that quietly re-read itself would hide exactly
+    the change an action's preconditions exist to catch.
+
+    So the node has to say when it has gone stale, and say it in a way an
+    action can act on. The distinction this exists for is the one §3.7 turns
+    on:
+
+    - `StaleElement` - *the screen moved*. Re-find the element and carry on, or
+      stop and hand back to a human. The action is not wrong.
+    - `FillFailed` / an empty search - *the selector is wrong*. The action was
+      written against a screen that is not this one, and running it again will
+      fail the same way.
+
+    Before this existed both arrived as "element supports no press action",
+    because a dead element reports no actions - true, and the least useful true
+    thing to say.
+    """
+
 #: Depth bound.  Deep enough to reach table cells in web content (which sit at
 #: about 10) without following an Electron tree to its bottom.
 DEFAULT_MAX_DEPTH = 14

--- a/keyhac/platform/mac/uielement.py
+++ b/keyhac/platform/mac/uielement.py
@@ -317,8 +317,29 @@ class UIElement:
         err, names = AS.AXUIElementCopyActionNames(self._ref, None)
         return [str(n) for n in names] if err == 0 and names else []
 
-    def perform_action(self, name: str) -> None:
-        AS.AXUIElementPerformAction(self._ref, name)
+    def perform_action(self, name: str) -> bool:
+        """Run an action, and report whether the OS accepted it.
+
+        The result used to be discarded, which made a press on an element that
+        had gone away indistinguishable from one that worked - the silent
+        wrong thing §3.7 exists to refuse. Windows already returned a bool
+        here; now both do.
+        """
+        return AS.AXUIElementPerformAction(self._ref, name) == 0
+
+    def is_stale(self) -> bool:
+        """True when the element this reference points at no longer exists.
+
+        Asked with the cheapest possible read: AX answers
+        kAXErrorInvalidUIElement for a reference whose element is gone, and
+        that is a different error from "this element has no AXRole", so a
+        control that simply lacks the attribute is not mistaken for a dead one.
+
+        A fact, not a policy - `keyhac.core.uitree.StaleElement` is raised by
+        the layer that decides what to do about it.
+        """
+        err, _ = AS.AXUIElementCopyAttributeValue(self._ref, "AXRole", None)
+        return err == AS.kAXErrorInvalidUIElement
 
     @staticmethod
     def get_focused_application() -> "UIElement | None":

--- a/keyhac/platform/win/uielement.py
+++ b/keyhac/platform/win/uielement.py
@@ -66,6 +66,11 @@ if sys.platform == "win32":
     COINIT_APARTMENTTHREADED = 0x2
     CLSCTX_INPROC_SERVER = 0x1
     S_OK = 0
+    # The element has been destroyed since we got a pointer to it.  Distinct
+    # from a property simply not being supported, which is what lets
+    # is_stale() tell "the screen moved" from "this control does not answer
+    # that".
+    UIA_E_ELEMENTNOTAVAILABLE = 0x80040201
     S_FALSE = 1
     RPC_E_CHANGED_MODE = -2147417850  # 0x80010106
 
@@ -573,6 +578,29 @@ class UIElement:
             return _com_call(pattern, slot, ctypes.c_long, []) == S_OK
         finally:
             _release(pattern)
+
+    def is_stale(self) -> bool:
+        """True when the element this pointer refers to no longer exists.
+
+        The cheapest read there is - a scalar property off the element itself,
+        no pattern to acquire - checked against the one HRESULT that means the
+        element is gone rather than the property being unavailable. Without the
+        distinction, a control that answers nothing would be reported dead.
+
+        A fact, not a policy - `keyhac.core.uitree.StaleElement` is raised by
+        the layer that decides what to do about it.
+
+        STATUS: written on macOS against UIAutomationClient.h and not yet run
+        on Windows. `tools/uia_pass.py` is where that gets settled; the slot it
+        uses (get_CurrentControlType, 21) is already pinned live by the
+        attribute reader above, so what is unverified here is the HRESULT
+        comparison rather than the call.
+        """
+        control_type = ctypes.c_int()
+        hr = _com_call(self._ptr, _IUIAutomationElement.get_CurrentControlType,
+                       ctypes.c_long, [ctypes.POINTER(ctypes.c_int)],
+                       ctypes.byref(control_type))
+        return (hr & 0xFFFFFFFF) == UIA_E_ELEMENTNOTAVAILABLE
 
     def set_value(self, value: str) -> bool:
         """Write through the Value pattern (the editable-control setter)."""

--- a/keyhac/skills/keyhac-action-authoring/references/api.md
+++ b/keyhac/skills/keyhac-action-authoring/references/api.md
@@ -8,7 +8,7 @@ The whole import list, and there is nothing else to reach for:
 
 ```python
 from keyhac import (ThreadedAction, WaitTimeout, FillFailed, ActionCancelled,
-                    UINode, getLogger)
+                    StaleElement, UINode, getLogger)
 
 logger = getLogger("MyAction")     # `logger` is NOT importable - make one
 ```
@@ -124,6 +124,31 @@ is for making several reads atomic against a moving UI, or for calling a
 platform element method this API does not wrap. `starting()` and `finished()`
 already run there; `run()` does not, and must not block it — waiting there
 raises rather than freezing the keyboard.
+
+## A node is a snapshot
+
+`ui.window(...)`, `find`, `find_all` and a walked tree all hand back nodes that
+record what an element **was**. The screen moves on; the node does not notice.
+It is deliberate — a node that quietly re-read itself would hide the very
+change your preconditions exist to catch.
+
+So do not keep nodes across a state change. Re-find after anything that could
+have redrawn:
+
+```python
+row = window.find(identifier="row-3")
+next_page.press()
+row.press()                        # WRONG - that row belonged to page 2
+```
+
+`node.reread()` refreshes a subtree when you genuinely want the same place
+again. Acting on a node whose element has gone raises `StaleElement`, and the
+distinction is the one that decides what to do next:
+
+| | means | what to do |
+|---|---|---|
+| `StaleElement` | the screen moved | re-find it, or stop and report — your action is not wrong |
+| `FillFailed`, an empty `find` | the selector is wrong | the action was written against a different screen; regenerating is the fix |
 
 ## Cancellation
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -235,3 +235,63 @@ def test_preserve_clipboard_serializes_across_threads():
         t.join(10)
 
     assert max(overlaps) == 1, f"two threads were inside at once: {overlaps}"
+
+
+# -- staleness ---------------------------------------------------------------
+#
+# A UINode is a snapshot (uitree.StaleElement documents why). These pin the
+# distinction that the contract is worth having for: "the screen moved" and
+# "your selector is wrong" used to arrive as the same message.
+
+class DeadElement:
+    """An element that has gone away, the way a closed dialog's button has."""
+    def is_stale(self):
+        return True
+    def get_action_names(self):
+        return []                       # what a dead element reports
+
+
+class LiveButNotPressable:
+    """A real element that simply offers no press action."""
+    def is_stale(self):
+        return False
+    def get_action_names(self):
+        return ["AXShowMenu"]
+
+
+class Ancient:
+    """A duck-typed element from before is_stale existed."""
+    def get_action_names(self):
+        return []
+
+
+def test_a_vanished_element_says_so_rather_than_blaming_the_selector():
+    from keyhac.core.fill import _press
+    from keyhac.core.uitree import StaleElement
+
+    with pytest.raises(StaleElement) as caught:
+        _press(DeadElement())
+    assert "no longer on screen" in str(caught.value)
+
+
+def test_a_live_element_with_no_press_action_still_reports_that():
+    from keyhac.core.fill import FillFailed, _press
+
+    with pytest.raises(FillFailed) as caught:
+        _press(LiveButNotPressable())
+    assert "supports no press action" in str(caught.value)
+
+
+def test_staleness_is_an_ordinary_exception():
+    """Unlike ActionCancelled: an action that wants to re-find the element and
+    carry on should be able to catch this in the handler it already has."""
+    from keyhac.core.uitree import StaleElement
+    assert issubclass(StaleElement, Exception)
+
+
+def test_an_element_without_is_stale_is_unaffected():
+    """register_action and the tests both accept duck-typed elements."""
+    from keyhac.core.fill import FillFailed, _press
+
+    with pytest.raises(FillFailed):
+        _press(Ancient())

--- a/tools/generate_api_reference.py
+++ b/tools/generate_api_reference.py
@@ -113,6 +113,7 @@ ACTION_API_NAMES = [
     "WaitTimeout",
     "FillFailed",
     "ActionCancelled",
+    "StaleElement",
 ]
 
 ACTION_HEADER = """# Action API reference


### PR DESCRIPTION
Closes §11's **UI tree API shape** — the question the experimental marker was
really about, since it is the ceiling on action expressiveness and a later
change breaks every action.

It closes in three pieces, and two were already closed without anyone writing
it down.

- **How far to unify Windows and macOS** — §10 step 4 answered it: at the API
  as far as it already goes, at the action not at all.
- **Element identity** — practice answered it. Address by `identifier` (DOM id
  / AXIdentifier / AutomationId) where there is one, since it survives
  relabelling and localisation, then role plus name or text — with the limit
  §10 step 4 found, that a DOM id reaches controls, tables and landmarks but
  not a plain `<span>`. `identity_key()` reads like the same question and is
  not: the raw platform ref, one caller, the DAG dedupe in `get_ui_tree`.
- **Handle lifetime** — **snapshot**, and that is the decision. A node records
  what an element *was*; the screen moves on and it does not notice;
  `reread()` refreshes one deliberately. Nodes that quietly re-read themselves
  would hide the exact change §3.7's preconditions exist to catch, and §7.2's
  three-beat pattern already re-finds rather than re-uses.

## The gap that had to be filled first — which was a bug

A dead element reports no actions. So `press()` on a button whose dialog had
closed raised:

```
FillFailed: element supports no press action (has [])
```

True, and the least useful true thing to say: it points the operator at their
selector when the screen had simply moved. **On macOS it was worse** —
`perform_action` discarded the AXError entirely, so a press on a stale
reference was indistinguishable from one that worked. That is the silent wrong
thing §3.7 refuses.

`StaleElement` joins `WaitTimeout` / `FillFailed` / `ActionCancelled` and buys
the distinction that decides what happens next:

| | means | what to do |
|---|---|---|
| `StaleElement` | the screen moved | re-find it, or stop and report — the action is not wrong |
| `FillFailed`, an empty `find` | the selector is wrong | regenerate the action |

Demonstrated:

```
dialog closed underneath us        -> StaleElement: the element is no longer on screen
selector points at the wrong thing -> FillFailed: element supports no press action (has ['AXShowMenu'])
```

**Layering kept.** `is_stale()` on both platform elements answers a question;
core decides what it means. macOS asks with the cheapest read there is and
compares against `kAXErrorInvalidUIElement` *specifically*, so a control that
merely lacks `AXRole` is not reported dead; Windows against
`UIA_E_ELEMENTNOTAVAILABLE`, for the same reason. `perform_action` now returns
a bool on macOS as it already did on Windows.

## Unverified, and marked so in §11

The Windows `is_stale()` was written on macOS against the header and has not
been run. `tools/uia_pass.py` is where that gets settled — the vtable slot it
uses is already pinned live, so what is untested is the HRESULT comparison
rather than the call.

## Checks

- 381 passed, 16 skipped
- `make api-reference-check` clean; skill evals pass; bundle rebuilds
- The contract is in `doc/action_api.md` (generated from the docstring) and in
  the skill, where it is the practical half: do not keep a node across a state
  change, re-find after anything that redraws

With this, the technical condition for removing the experimental marker is met.
What remains is the evidence condition — actions generated on Windows as well
as macOS, by more than one person — which is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)