### PR TITLE
run_action hands back what the action produced — and becomes two calls

### DIFF
--- a/doc/ai-integration.md
+++ b/doc/ai-integration.md
@@ -228,10 +228,11 @@ screen coordinates.
 | `find_elements` | targeted search by role / name / identifier / text |
 | `read_text` | an element's whole text — terminal scrollback, editor buffer |
 | `enable_content_access` | make a Chromium/Electron app expose its content (macOS) |
-| `list_actions`, `run_action` | run a registered action and return what it logged |
+| `list_actions` | what is registered, what is running, how each last ended |
+| `start_action`, `get_action_result`, `cancel_action` | start a registered action, collect what it logged, stop it |
 | `reload_config` | pick up an edited action without restarting |
 
-`run_action` only runs actions you have registered by name:
+`start_action` only runs actions you have registered by name:
 
 ```python
 keymap.register_action("extract_records", ExtractRecords())
@@ -293,6 +294,7 @@ don't type passwords or show private material while recording.
 - **No tool writes files or types text.** Reading trees and pressing buttons in
   an app you are looking at is one thing; letting a remote model put Python on
   your disk is another decision, and it has not been made.
-- **`run_action` is limited to registered actions**, by name.
+- **`start_action` is limited to registered actions**, by name, and
+  `cancel_action` can only stop what it started.
 - Turn it off with the same switch; the token file is deleted then, and when
   Keyhac stops.

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -895,7 +895,9 @@ Anything slow - network, subprocess, sleeping, heavy computation - must not run 
 
 Three threads, and which one you are on decides what you may touch. starting() and finished() run on the event-loop thread under the engine lock: main-thread-only APIs (UI, windows, AX) are allowed there, and they should stay light-weight because they hold the lock the keyboard hook needs.  run() executes on a worker, where input contexts are allowed but windows and AX elements are not. 
 
-The pool is a single worker shared by every threaded action, so a run() that sleeps or loops delays every other one until it returns. 
+Actions run concurrently, so a run() that takes minutes no longer holds up every other one.  What is still serialized is what has to be: injected keystrokes (one `with ctx:` batch at a time) and the clipboard save and restore around a paste. 
+
+**The user can stop a running action with Esc**, and an action needs to write nothing for that: `wait_for` raises `ActionCancelled`, and a long action spends nearly all its time waiting.  Use `check_cancelled()` in a stretch of work that has no wait in it. 
 
 ```python
 class Fetch(ThreadedAction):

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -1106,7 +1106,7 @@ Against the layers in §5 and the sequence in §10:
 | Layer 1 — observation | Event subscription **dropped** after measuring (§5). Trace capture **not ours to build** — Claude Desktop records and narrates; §5 has the reasoning. |
 | Layer 2 — state reading | **Done**, both platforms. `keymap.ui` + `UINode`, the text layer, verified live on macOS and Windows. |
 | Layer 3 — execution safety | **Partial, and less so.** Waiting, read-back, **`Esc` cancellation** and **the executor** are in; the `max_workers=1` bug §2.1 named is gone. Per-step preconditions, checkpointing and idempotency remain *patterns the actions follow*, not framework: `Action.preconditions()` and dry-run/preview are **not built**. |
-| Layer 4 — action metadata | **Minimal.** `keymap.register_action(name, action)` and the MCP tool schemas; no argument schema, no description surface. |
+| Layer 4 — action metadata | **Minimal, plus run state.** `keymap.register_action(name, action)` and the MCP tool schemas; still no argument schema and no description surface. `list_actions` now also reports what is running and how each last ended, and `get_action_result` serves the run itself (§15.4). |
 | Layer 5 — artifact management | **Not built.** No `~/.keyhac/actions/*.py` discovery, no partial reload, no tool that writes Python to disk. Generated actions are pasted in by hand. |
 | Topology A — MCP | **Done.** `keyhac/mcp/`: nine tools over loopback HTTP with a per-start token, off unless the config asks; `keyhac-mcp-bridge` for Claude Desktop. See `doc/ai-integration.md`. |
 | Topology B — agent host | **Not built, and probably unnecessary** (§3.4). Nothing has needed runtime inference. |
@@ -1288,7 +1288,42 @@ capturing stdout for the duration of a run on the loop thread captures whatever
 else logs on that thread in the same window. Bound the output, and say in the
 result when it was truncated.
 
-### 15.4 A failing action should be able to hand the agent its own trace
+### 15.4 A failing action should be able to hand the agent its own trace — **done, as a side effect**
+
+It fell out of making the tools asynchronous, which is the second time on this
+page that the answer was to notice two problems were one.
+
+The transport answers one message per request and has no stream to push
+progress over (`server.py`: no GET, no SSE, no sessions), while §2's actions
+run for minutes — so `run_action` could not wait for the end without timing out
+for exactly the workload it exists to serve, and the bridge's 60-second cap
+made that concrete. Splitting it into **`start_action`** and
+**`get_action_result`** means a run's output has to live somewhere retrievable
+rather than being the return value of the call that started it.
+
+Which is what this section asked for. Once that store exists, the entry point
+that fills it is `ThreadedAction.cancellable()` — the same seam Esc uses — so a
+run started by a **key press** records itself identically. "The PDF one failed
+this morning" is now `get_action_result("print-tabs")`, with the traceback, the
+subprocess stderr, and how far it got.
+
+The open questions answered themselves, mostly conservatively:
+
+- **Where it lives, and for how long.** Memory only, one run per action, a
+  second run replacing the first. A record holds window titles and element
+  names, which is §9's material, and the conservative answer there is the one
+  taken here: nothing on disk, nothing accumulating.
+- **Whether the operator is prompted.** No. The record simply exists for an
+  agent that asks, which is what this section preferred.
+- **Whether a repeated failure notifies.** Still not built, and still against
+  Keyhac's posture of staying out of the way.
+
+`cancel_action` came along with it: refusing a model the ability to stop what it
+was allowed to start is the odd asymmetry, and stopping is the safer half.
+
+The original note follows.
+
+---
 
 Today the loop is: the action fails, the operator notices something did not
 happen, opens the Keyhac console, finds the traceback, copies it, pastes it

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -1228,7 +1228,43 @@ Two directions, and they are not the same size:
 Answer the second before investing in the first: they solve the same problem
 and only one of them survives.
 
-### 15.3 `run_action` returns logs, not output
+### 15.3 `run_action` returns logs, not output — **done**
+
+**Two of the three are fixed and the third could not be, which turned out to be
+the useful finding.** `print()` and non-`keyhac` loggers now come back;
+subprocess stderr cannot, because a child process writes to a real file
+descriptor rather than to Python's `sys.stderr`, so no wrapper installed in
+this process ever sees it. It survives only on the exception, and only when the
+action asked for it — so `run_action` surfaces `CalledProcessError.stderr` when
+it is there, **and says so when it is not**, which is what turns "returned 1"
+into a fixable line rather than a mystery. The skill now tells actions to shell
+out with `capture_output=True`.
+
+Two things the implementation ran into that the note below did not anticipate:
+
+- **The handler has to sit on both root and `keyhac`.** `core/log.py`
+  configures the `keyhac` logger with `propagate=False`, so moving the handler
+  to root — the obvious reading of "root logger rather than `keyhac`" — captured
+  *nothing at all* from the documented `getLogger()`. Because it does not
+  propagate, attaching to both duplicates nothing either.
+- **Streams are teed, not redirected.** `redirect_stdout` would have taken
+  `print()` away from the console window, and the operator watching it is not
+  who this change was for.
+
+The "what does that sweep in" question resolved as: root at INFO rather than
+DEBUG, so a library's debug chatter stays out while its warnings arrive; and
+capture is global while active rather than thread-filtered, because an action's
+`starting()` and `finished()` run on the loop thread while `run()` does not — a
+thread filter would have dropped exactly the two halves that report what
+happened. Two overlapping runs therefore see each other's lines, which is worth
+saying out loud and is still better than the model seeing none of its own.
+
+Output is capped at 20k characters, keeping the **tail** — where the failure is
+— and saying how much was dropped.
+
+The original note follows.
+
+---
 
 Verified in `keyhac/mcp/tools.py`: `_captured_log` installs a
 `logging.Handler` on the `keyhac` logger for the duration of the run. So an

--- a/keyhac/core/action.py
+++ b/keyhac/core/action.py
@@ -1,8 +1,13 @@
 """Threaded actions (ported from keyhac-mac keyhac_action.py).
 
 starting()/finished() run on the event-loop thread under the engine lock
-(serialized with the hook); run() executes in a shared single-worker thread
-pool.
+(serialized with the hook); run() executes on a shared pool, concurrently with
+other actions.
+
+Two things beyond that lifecycle live here, and both exist because an action of
+the kind this framework serves runs for minutes rather than milliseconds: it
+can be stopped with Esc, and what it produced is recorded where something can
+come back for it (keyhac/core/capture.py).
 """
 
 import contextlib
@@ -11,7 +16,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from keyhac.core import log
+from keyhac.core import capture, log
 
 logger = log.getLogger("Action")
 
@@ -72,8 +77,15 @@ class ThreadedAction:
     needs.  run() executes on a worker, where input contexts are allowed but
     windows and AX elements are not.
 
-    The pool is a single worker shared by every threaded action, so a run()
-    that sleeps or loops delays every other one until it returns.
+    Actions run concurrently, so a run() that takes minutes no longer holds up
+    every other one.  What is still serialized is what has to be: injected
+    keystrokes (one `with ctx:` batch at a time) and the clipboard save and
+    restore around a paste.
+
+    **The user can stop a running action with Esc**, and an action needs to
+    write nothing for that: `wait_for` raises `ActionCancelled`, and a long
+    action spends nearly all its time waiting.  Use `check_cancelled()` in a
+    stretch of work that has no wait in it.
 
     ```python
     class Fetch(ThreadedAction):
@@ -178,13 +190,19 @@ class ThreadedAction:
             return self.run()
 
     @contextlib.contextmanager
-    def cancellable(self):
-        """Make this action reachable by Esc for the duration of the block.
+    def cancellable(self, name: str | None = None):
+        """Make this action reachable by Esc, and record what it produces.
 
-        Both ways of starting an action enter this: `_run_tracked` for a key
-        press, and the MCP `run_action` tool, which drives the lifecycle
-        itself. Without it, an action started from a chat window would be the
-        one you could not stop.
+        `name` is what the run is filed under. A caller that knows it - the
+        MCP tool, which was handed a name to look the action up by - passes it
+        rather than letting the lookup below go through the Keymap singleton,
+        which is not necessarily the registry it came from.
+
+        Both ways of starting an action enter this - `_run_tracked` for a key
+        press, and the MCP tool that starts one from a chat window - which is
+        what makes both stoppable and both retrievable. A run started by a key
+        this morning is the one §15.4 wants readable at noon, and it lands here
+        by taking the same path.
 
         The flag is built here rather than in `__init__` because subclasses
         write their own and do not call `super()` - the documented shape, and
@@ -198,12 +216,43 @@ class ThreadedAction:
         _current.action = self
         with ThreadedAction._running_lock:
             ThreadedAction._running.add(self)
+
+        self._run_record = capture.start_run(name or self._registered_name())
         try:
-            yield self
+            with capture.capture(self._run_record.output):
+                yield self
+        except ActionCancelled:
+            self._run_record.finish("cancelled", "stopped with Esc")
+            raise
+        except BaseException as error:                    # noqa: BLE001
+            self._run_record.finish(
+                "failed",
+                "the action raised:\n" + traceback.format_exc()
+                + capture.subprocess_detail(error))
+            raise
+        else:
+            self._run_record.finish("finished")
         finally:
             _current.action = None
             with ThreadedAction._running_lock:
                 ThreadedAction._running.discard(self)
+
+    def _registered_name(self) -> str:
+        """The name this action was registered under, for the run record.
+
+        Reversed out of the registry rather than stored, so an action that was
+        never registered still gets a record - under its repr, which is what a
+        key binding has instead of a name.
+        """
+        try:
+            from keyhac.core.keymap import Keymap
+            registry = getattr(Keymap.get_instance(), "registered_actions", {})
+            for name, action in registry.items():
+                if action is self:
+                    return name
+        except Exception:                                 # noqa: BLE001
+            pass
+        return repr(self)
 
     def _done_callback(self, future):
         # add_done_callback fires on the pool thread; hand finished() back to

--- a/keyhac/core/capture.py
+++ b/keyhac/core/capture.py
@@ -1,0 +1,292 @@
+"""What an action produced, kept where something can come back for it.
+
+Two things live here because they are the same thing seen twice.
+
+**Capture** collects an action's output while it runs - `logger.info`, `print`,
+a library's warnings - so a model can read its own failure instead of the
+operator copying a traceback out of a console window
+(doc/dev/ai-integration.md §15.3).
+
+**The run record** keeps that output, and how the run ended, per action. An
+action takes minutes; the transport that starts it answers in one message
+(§15.3 again - the endpoint is POST-only JSON-RPC, so there is no channel to
+stream progress over). So starting and collecting are separate steps, and this
+is where the second one looks. It is also, unchanged, what §15.4 asked for: an
+action that fails at nine in the morning has its traceback here when somebody
+asks about it at noon.
+
+**Memory only, one run per action.** A record holds window titles and element
+names, which is the material §9's trace-privacy rules cover, and the answer
+there was deliberately conservative. Nothing is written to disk and nothing
+accumulates.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import sys
+import threading
+import time
+
+#: Ceiling on what one run keeps. A run that logs a line per row over hundreds
+#: of rows would otherwise fill a context window with the middle of its own
+#: progress bar; the tail is where the failure is, so that is the end kept.
+MAX_CAPTURE = 20_000
+
+#: Captures currently collecting log records. Global rather than per-thread on
+#: purpose: an action's `starting()` and `finished()` run on the loop thread
+#: while `run()` does not, so a thread filter would drop exactly the two halves
+#: that report what happened. Two overlapping runs therefore see each other's
+#: log lines, which is a small price - records carry their logger's name - for
+#: not losing the halves that say how the run ended.
+_captures: list = []
+
+#: Where `print()` on *this* thread goes. Thread-scoped where the log handler
+#: is not, and the difference is not fussiness: a run lasts minutes, and a
+#: global stdout tee spent all of them absorbing every unrelated print in the
+#: process into whichever action happened to be running. An action's own
+#: print() happens on the thread running its run(), so the thread is exactly
+#: the right scope. The cost is a print() from starting()/finished() - which
+#: run elsewhere - and those log instead.
+_stream_target = threading.local()
+
+#: Guards the stream swap only. The list needs no lock - append and remove are
+#: atomic - but two runs starting together could both believe they were first
+#: and install a tee over a tee.
+_captures_lock = threading.Lock()
+
+
+class Bounded:
+    """A buffer that keeps the last MAX_CAPTURE characters and says so."""
+
+    def __init__(self):
+        self._parts: list[str] = []
+        self._size = 0
+        self.dropped = 0
+
+    def write(self, text: str) -> int:
+        self._parts.append(text)
+        self._size += len(text)
+        while self._size > MAX_CAPTURE and len(self._parts) > 1:
+            gone = self._parts.pop(0)
+            self._size -= len(gone)
+            self.dropped += len(gone)
+        return len(text)
+
+    def getvalue(self) -> str:
+        body = "".join(self._parts)
+        if self.dropped:
+            return (f"[{self.dropped} earlier characters dropped - this is the "
+                    f"tail of the run]\n{body}")
+        return body
+
+
+class _Handler(logging.Handler):
+    def __init__(self, buffer: Bounded):
+        super().__init__()
+        self.buffer = buffer
+
+    def emit(self, record):
+        self.buffer.write(self.format(record) + "\n")
+
+
+class _Tee:
+    """`sys.stdout`, plus every active capture.
+
+    Wraps rather than replaces, because print() must keep reaching the console
+    window - the operator watching it is not who capture is for.
+    """
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def write(self, text) -> int:
+        buffer = getattr(_stream_target, "buffer", None)
+        if buffer is not None:
+            buffer.write(str(text))
+        return self._wrapped.write(text)
+
+    def flush(self) -> None:
+        self._wrapped.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+@contextlib.contextmanager
+def capture(buffer: Bounded | None = None):
+    """Collect everything the enclosed code logs or prints.
+
+    Three kinds of output used to reach the console window and not the model;
+    two of them now do both.
+
+    - **print()**, which the shipped config.py template teaches on the same
+      line as the logger. Teed rather than redirected, so it still reaches the
+      console.
+    - **Loggers outside the `keyhac` tree** - `getLogger(__name__)` in a module
+      under `extensions/`, and any library the action imports.
+    - **Subprocess stderr** is the one this cannot reach: a child writes to a
+      real file descriptor, not to Python's `sys.stderr`. It survives only on
+      the exception, which is why callers surface `CalledProcessError.stderr`
+      separately and the skill says to pass `capture_output=True`.
+    """
+    buffer = buffer if buffer is not None else Bounded()
+    handler = _Handler(buffer)
+    handler.setFormatter(
+        logging.Formatter("%(levelname)s [%(name)s] %(message)s"))
+
+    # Both, and it is not belt-and-braces. `keyhac` is configured with
+    # propagate=False (core/log.py), so a record from the documented
+    # getLogger() never reaches root - attaching only there captured nothing.
+    # Because it does not propagate, nothing is emitted twice either.
+    loggers = (logging.getLogger(), logging.getLogger("keyhac"))
+    for target in loggers:
+        target.addHandler(handler)
+
+    # A root handler only sees what root's level admits, and the default is
+    # WARNING - which would drop every logger.info() an action writes. INFO
+    # rather than DEBUG: DEBUG would pull in the debug chatter of every library
+    # the action imports, and a model is reading this.
+    level = loggers[0].level
+    if level == logging.NOTSET or level > logging.INFO:
+        loggers[0].setLevel(logging.INFO)
+
+    previous = getattr(_stream_target, "buffer", None)
+    _stream_target.buffer = buffer
+    with _captures_lock:
+        _captures.append(buffer)
+        first = len(_captures) == 1 and not isinstance(sys.stdout, _Tee)
+        streams = (sys.stdout, sys.stderr) if first else None
+        if first:
+            sys.stdout, sys.stderr = _Tee(sys.stdout), _Tee(sys.stderr)
+    try:
+        yield buffer
+    finally:
+        _stream_target.buffer = previous
+        for target in loggers:
+            target.removeHandler(handler)
+        loggers[0].setLevel(level)
+        with _captures_lock:
+            try:
+                _captures.remove(buffer)
+            except ValueError:
+                pass
+            if streams is not None and not _captures:
+                sys.stdout, sys.stderr = streams
+
+
+def subprocess_detail(error: BaseException) -> str:
+    """What a failed subprocess said, which capture cannot see.
+
+    Saying so when it said nothing is worth more than silence: "returned 1"
+    with no reason is where the run-read-fix loop stalls, and the fix is a line
+    in the action rather than a mystery.
+    """
+    output = getattr(error, "stderr", None) or getattr(error, "output", None)
+    if isinstance(output, bytes):
+        output = output.decode("utf-8", "replace")
+    if output:
+        return f"\nthe subprocess wrote to stderr:\n{output.strip()}\n"
+    if getattr(error, "returncode", None) is not None:
+        return ("\n(the subprocess left no stderr here - it was run without "
+                "capture_output=True, so what it said went to the terminal "
+                "Keyhac was started from and nowhere this can reach)\n")
+    return ""
+
+
+# -- the run record ----------------------------------------------------------
+
+#: The last run of each action, by the name it was registered under.  One
+#: entry per action: a second run replaces the first rather than piling up.
+_runs: dict = {}
+_runs_lock = threading.Lock()
+
+#: Signalled whenever any run ends, so a reader waiting for one is woken
+#: instead of polling for it.
+_finished = threading.Condition()
+
+
+class ActionRun:
+    """How one run of one action went, and what it said while going."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.status = "running"
+        self.output = Bounded()
+        self.detail: str | None = None      # traceback, or why it stopped
+        self.started = time.monotonic()
+        self.ended: float | None = None
+
+    @property
+    def running(self) -> bool:
+        return self.status == "running"
+
+    @property
+    def seconds(self) -> float:
+        return (self.ended or time.monotonic()) - self.started
+
+    def finish(self, status: str, detail: str | None = None) -> None:
+        self.status = status
+        self.detail = detail
+        self.ended = time.monotonic()
+        with _finished:
+            _finished.notify_all()
+
+    def report(self) -> str:
+        """The whole of what a caller came back for."""
+        head = (f"{self.name}: {self.status} after {self.seconds:.1f}s"
+                if not self.running else
+                f"{self.name}: still running after {self.seconds:.1f}s")
+        body = self.output.getvalue().strip()
+        parts = [head]
+        if body:
+            parts.append(body)
+        if self.detail:
+            parts.append(self.detail.strip())
+        if self.running:
+            parts.append("(call get_action_result again for the rest, or "
+                         "cancel_action to stop it)")
+        return "\n\n".join(parts)
+
+
+def start_run(name: str) -> ActionRun:
+    """Record that `name` has begun, replacing whatever it did last time."""
+    run = ActionRun(name)
+    with _runs_lock:
+        _runs[name] = run
+    return run
+
+
+def get_run(name: str) -> ActionRun | None:
+    with _runs_lock:
+        return _runs.get(name)
+
+
+def running_names() -> set:
+    with _runs_lock:
+        return {name for name, run in _runs.items() if run.running}
+
+
+def wait_for_run(name: str, seconds: float) -> ActionRun | None:
+    """Block up to `seconds` for `name`'s run to end, then report either way.
+
+    Waiting rather than returning immediately is what keeps a fast action fast:
+    the caller pays two round trips instead of one, but no extra latency. And
+    "still running" is a normal answer here rather than a timeout, which is the
+    difference between this and a transport that gives up.
+    """
+    run = get_run(name)
+    if run is None:
+        return None
+    deadline = time.monotonic() + max(0.0, seconds)
+    with _finished:
+        while run.running:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            _finished.wait(remaining)
+    return run

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -30,7 +30,7 @@ import sys
 import threading
 import traceback
 
-from keyhac.core import log
+from keyhac.core import capture, log
 from keyhac.core.action import ActionCancelled
 
 logger = log.getLogger("MCP")
@@ -172,20 +172,47 @@ class ToolRegistry:
                                 "False to turn it back off when done."}}},
                  self.enable_content_access),
             Tool("list_actions",
-                 "The actions this configuration has registered by name, and "
-                 "which of them run_action can run.",
+                 "The actions this configuration has registered by name, "
+                 "which are running now, and how the last run of each ended.",
                  {"type": "object", "properties": {}},
                  self.list_actions),
-            Tool("run_action",
-                 "Run a registered action and return everything it logged, "
-                 "including the traceback if it raised. This is how you check "
-                 "your own work: write the action, have the operator save and "
-                 "reload it, run it, read what happened, fix it.",
+            Tool("start_action",
+                 "Start a registered action and return immediately. **It is "
+                 "not finished when this returns** - call get_action_result "
+                 "for what it did. Actions here drive real applications and "
+                 "can take minutes, which is why starting and collecting are "
+                 "separate steps.",
                  {"type": "object", "properties": {
                      "name": {**string, "description":
                               "Name from list_actions."}},
                   "required": ["name"]},
-                 self.run_action),
+                 self.start_action),
+            Tool("get_action_result",
+                 "Wait for an action to finish and return everything it "
+                 "logged or printed, with the traceback if it raised. Blocks "
+                 "up to `wait` seconds; if it is still running when that is "
+                 "up, that is the answer - call again. This is how you check "
+                 "your own work: write the action, have the operator save and "
+                 "reload it, start it, read what happened, fix it. It also "
+                 "holds the last run of an action the operator triggered with "
+                 "a key, so \"the PDF one failed this morning\" is answerable.",
+                 {"type": "object", "properties": {
+                     "name": {**string, "description":
+                              "Name from list_actions."},
+                     "wait": {**integer, "description":
+                              "Seconds to wait for it to finish (default 30, "
+                              "0 to look without waiting)."}},
+                  "required": ["name"]},
+                 self.get_action_result),
+            Tool("cancel_action",
+                 "Stop a running action - the same thing the operator's Esc "
+                 "does. It unwinds rather than being killed, so progress it "
+                 "has already recorded stays recorded.",
+                 {"type": "object", "properties": {
+                     "name": {**string, "description":
+                              "Name from list_actions."}},
+                  "required": ["name"]},
+                 self.cancel_action),
             Tool("reload_config",
                  "Reload ~/.keyhac/config.py, so an edited or newly added "
                  "action is picked up without restarting Keyhac. Reports the "
@@ -322,47 +349,98 @@ class ToolRegistry:
         if not actions:
             return ("no actions registered. A configuration registers one "
                     "with keymap.register_action(\"name\", TheAction()).")
-        return "\n".join(f"{name}: {action!r}" for name, action in
-                         sorted(actions.items()))
+        running = capture.running_names()
+        lines = []
+        for name, action in sorted(actions.items()):
+            run = capture.get_run(name)
+            if name in running:
+                state = f"RUNNING for {run.seconds:.0f}s"
+            elif run is not None:
+                state = f"last run: {run.status}"
+            else:
+                state = "not run yet"
+            lines.append(f"{name}: {action!r} - {state}")
+        return "\n".join(lines)
 
-    def run_action(self, name: str) -> str:
+    def _action(self, name: str):
         action = self.keymap.registered_actions.get(name)
         if action is None:
             raise KeyError(f"no action named {name!r}; call list_actions")
+        return action
 
-        # Still not through ThreadedAction.__call__, but for one reason now
-        # rather than two. The pool no longer serializes everything behind a
-        # single worker, so queueing is no longer the problem; what remains is
-        # that __call__ returns as soon as it has submitted, and this tool has
-        # to hand back what the action logged. Registering with _running is
-        # what matters, and is done explicitly below, so Esc reaches an action
-        # started from here exactly as it reaches one started from a key.
-        with _captured_log() as captured:
-            try:
+    def start_action(self, name: str) -> str:
+        """Start it and get out of the way.
+
+        Asynchronous by design rather than because the transport forced it.
+        The endpoint answers one JSON message per request with no stream to
+        push progress over, and §2's actions run for minutes - so a call that
+        waited for the end would be a call that times out for exactly the
+        class of work this exists to serve. Two shapes of reply depending on
+        how fast the action happened to be would be worse still: the branch
+        would hinge on the least predictable thing there is.
+        """
+        action = self._action(name)
+        if capture.get_run(name) is not None and capture.get_run(name).running:
+            return (f"{name} is already running - get_action_result to watch "
+                    f"it, or cancel_action to stop it.")
+
+        def drive():
+            with action.cancellable(name) if hasattr(action, "cancellable") \
+                    else contextlib.nullcontext():
                 if hasattr(action, "run"):
                     self.ui.on_main_thread(action.starting)
-                    # register_action is duck-typed - anything with run() is
-                    # accepted - so an action that is not a ThreadedAction
-                    # still runs here, just without being cancellable.
-                    track = getattr(action, "cancellable", contextlib.nullcontext)
-                    with track():
-                        result = action.run()
+                    result = action.run()
                     self.ui.on_main_thread(lambda: action.finished(result))
                 else:
                     self.ui.on_main_thread(action)
+
+        # A duck-typed action - register_action accepts anything with run() -
+        # has no cancellable() to record itself, so the record is opened here
+        # for it and closed by whichever arm finishes.
+        plain = not hasattr(action, "cancellable")
+        record = capture.start_run(name) if plain else None
+
+        def body():
+            try:
+                if plain:
+                    with capture.capture(record.output):
+                        drive()
+                    record.finish("finished")
+                else:
+                    drive()
             except ActionCancelled:
-                # Its own arm because it is a BaseException: the handler below
-                # would not see it, and it would leave through the HTTP layer
-                # as a server error rather than as the answer it is.
-                return (captured.getvalue()
-                        + f"\n{name} was cancelled with Esc. Whatever it "
-                          f"logged above is how far it got.")
-            except Exception as error:                    # noqa: BLE001
-                return (captured.getvalue()
-                        + "\nthe action raised:\n" + traceback.format_exc()
-                        + _subprocess_detail(error))
-        output = captured.getvalue().strip()
-        return output or f"{name} finished and logged nothing"
+                if plain:
+                    record.finish("cancelled", "stopped with Esc")
+            except BaseException as error:                # noqa: BLE001
+                if plain:
+                    record.finish(
+                        "failed",
+                        "the action raised:\n" + traceback.format_exc()
+                        + capture.subprocess_detail(error))
+
+        threading.Thread(target=body, name=f"mcp-{name}", daemon=True).start()
+        return (f"{name} started. Call get_action_result to see what it did.")
+
+    def get_action_result(self, name: str, wait: int = 30) -> str:
+        self._action(name)
+        run = capture.wait_for_run(name, float(wait))
+        if run is None:
+            return (f"{name} has not been run since Keyhac started. "
+                    f"start_action runs it.")
+        return run.report()
+
+    def cancel_action(self, name: str) -> str:
+        action = self._action(name)
+        run = capture.get_run(name)
+        if run is None or not run.running:
+            return f"{name} is not running."
+        flag = getattr(action, "_cancel_flag", None)
+        if flag is None:
+            return (f"{name} is running but cannot be cancelled - only a "
+                    f"ThreadedAction can be, and this is not one.")
+        flag.set()
+        return (f"asked {name} to stop. It unwinds at its next wait, so "
+                f"get_action_result for how far it got.")
 
     def reload_config(self) -> str:
         def reload():

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -25,8 +25,9 @@ directly, or through the node methods, which dispatch themselves.
 from __future__ import annotations
 
 import contextlib
-import io
 import logging
+import sys
+import threading
 import traceback
 
 from keyhac.core import log
@@ -356,9 +357,10 @@ class ToolRegistry:
                 return (captured.getvalue()
                         + f"\n{name} was cancelled with Esc. Whatever it "
                           f"logged above is how far it got.")
-            except Exception:                             # noqa: BLE001
+            except Exception as error:                    # noqa: BLE001
                 return (captured.getvalue()
-                        + "\nthe action raised:\n" + traceback.format_exc())
+                        + "\nthe action raised:\n" + traceback.format_exc()
+                        + _subprocess_detail(error))
         output = captured.getvalue().strip()
         return output or f"{name} finished and logged nothing"
 
@@ -373,31 +375,172 @@ class ToolRegistry:
         return output or "config reloaded"
 
 
+def _subprocess_detail(error: BaseException) -> str:
+    """What a failed subprocess said, which the stream capture cannot see.
+
+    A child process writes to the real file descriptor, not to Python's
+    `sys.stderr`, so no wrapper installed here observes it. The only place it
+    survives is on the exception - and only when the action asked for it, which
+    is why the skill says to shell out with `capture_output=True`. Saying so
+    when it did not is worth more than silence: "returned 1" with no reason is
+    where the loop stalls.
+    """
+    output = getattr(error, "stderr", None) or getattr(error, "output", None)
+    if isinstance(output, bytes):
+        output = output.decode("utf-8", "replace")
+    if output:
+        return f"\nthe subprocess wrote to stderr:\n{output.strip()}\n"
+    if getattr(error, "returncode", None) is not None:
+        return ("\n(the subprocess left no stderr here - it was run without "
+                "capture_output=True, so what it said went to the terminal "
+                "Keyhac was started from and nowhere this can reach)\n")
+    return ""
+
+
+#: Ceiling on what one run hands back. A run that logs a line per row over
+#: hundreds of rows would otherwise fill a context window with the middle of
+#: its own progress bar; the tail is where the failure is, so that is the end
+#: that is kept.
+MAX_CAPTURE = 20_000
+
+#: Captures currently collecting, and the lock around installing the stream
+#: tee. Global rather than per-thread on purpose: an action's `starting()` and
+#: `finished()` run on the loop thread while `run()` runs on this one, so a
+#: thread filter would drop exactly the two halves that report what happened.
+#: The cost is that two runs overlapping - possible now that the action pool
+#: has more than one worker - each see the other's lines. Interleaved context
+#: beats the previous behaviour, which was the model seeing none of it.
+_captures: list = []
+
+#: Guards the stream swap only. The list itself needs no lock - append and
+#: remove are atomic - but two runs starting together could both believe they
+#: were the first and install a tee over a tee.
+_captures_lock = threading.Lock()
+
+
+class _Bounded:
+    """A buffer that keeps the last MAX_CAPTURE characters and says so."""
+
+    def __init__(self):
+        self._parts: list[str] = []
+        self._size = 0
+        self.dropped = 0
+
+    def write(self, text: str) -> int:
+        self._parts.append(text)
+        self._size += len(text)
+        while self._size > MAX_CAPTURE and len(self._parts) > 1:
+            gone = self._parts.pop(0)
+            self._size -= len(gone)
+            self.dropped += len(gone)
+        return len(text)
+
+    def getvalue(self) -> str:
+        body = "".join(self._parts)
+        if self.dropped:
+            return (f"[{self.dropped} earlier characters dropped - this is the "
+                    f"tail of the run]\n{body}")
+        return body
+
+
 class _Capture(logging.Handler):
-    def __init__(self, stream):
+    def __init__(self, buffer):
         super().__init__()
-        self.stream = stream
+        self.buffer = buffer
 
     def emit(self, record):
-        self.stream.write(self.format(record) + "\n")
+        self.buffer.write(self.format(record) + "\n")
+
+
+class _Tee:
+    """`sys.stdout`, plus every active capture.
+
+    Wraps rather than replaces, because print() must keep reaching the console
+    window - the operator watching it is not who this change is for.
+    """
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+
+    def write(self, text) -> int:
+        for buffer in tuple(_captures):
+            buffer.write(str(text))
+        return self._wrapped.write(text)
+
+    def flush(self) -> None:
+        self._wrapped.flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
 
 
 class _captured_log:
-    """Collect everything logged while an action runs, to hand back.
+    """Collect what an action produced, to hand back to the model.
 
-    The point of run_action is that the model reads the failure itself; a tool
-    that returned "ok"/"failed" would leave the operator copying tracebacks,
-    which is the manual step it exists to remove.
+    The point of run_action is that the model reads its own failure; a tool
+    returning "ok"/"failed" leaves the operator copying tracebacks, which is
+    the manual step it exists to remove. Three things used to reach the
+    console window and not the model, and the first two now do:
+
+    - **print()**, which the shipped config.py template teaches on the same
+      line as the logger. Collected by teeing sys.stdout/sys.stderr rather
+      than redirecting them, so it still reaches the console as well.
+    - **Loggers outside the `keyhac` tree** - what `getLogger(__name__)` in a
+      module under `extensions/` produces. The handler sits on the root logger
+      now. That does sweep in every library the action imports, which is the
+      intended trade: a urllib retry storm is part of what went wrong.
+    - **Subprocess stderr** is the one this cannot reach. A child process
+      writes to the real file descriptor, not to Python's `sys.stderr`, so no
+      stream wrapper sees it. `run_action` surfaces it from
+      CalledProcessError instead, and the skill tells actions to shell out
+      with capture_output=True so there is something to surface.
     """
 
-    def __enter__(self) -> io.StringIO:
-        self.stream = io.StringIO()
-        self.handler = _Capture(self.stream)
+    def __enter__(self) -> "_Bounded":
+        self.buffer = _Bounded()
+        self.handler = _Capture(self.buffer)
         self.handler.setFormatter(
             logging.Formatter("%(levelname)s [%(name)s] %(message)s"))
-        self.root = logging.getLogger("keyhac")
-        self.root.addHandler(self.handler)
-        return self.stream
+        # Both, and it is not belt-and-braces. `keyhac` is configured with
+        # propagate=False (core/log.py), so a record from the documented
+        # getLogger() never reaches root - attaching only there captured
+        # nothing, which is what the tests caught. Because it does not
+        # propagate, nothing is emitted twice either: keyhac records stop at
+        # the keyhac handler, everything else - an extensions/ module's
+        # getLogger(__name__), a library - arrives at root.
+        self.loggers = (logging.getLogger(), logging.getLogger("keyhac"))
+        for target in self.loggers:
+            target.addHandler(self.handler)
+
+        # A root handler only sees what root's level admits, and the default is
+        # WARNING - which would have dropped every logger.info() an action
+        # writes. INFO rather than DEBUG on purpose: DEBUG here would pull in
+        # the debug chatter of every library the action imports, and the model
+        # is reading this.
+        self._level = self.loggers[0].level
+        if self._level == logging.NOTSET or self._level > logging.INFO:
+            self.loggers[0].setLevel(logging.INFO)
+
+        with _captures_lock:
+            _captures.append(self.buffer)
+            if len(_captures) == 1 and not isinstance(sys.stdout, _Tee):
+                self._streams = (sys.stdout, sys.stderr)
+                sys.stdout, sys.stderr = _Tee(sys.stdout), _Tee(sys.stderr)
+            else:
+                self._streams = None
+        return self.buffer
 
     def __exit__(self, *exc) -> None:
-        self.root.removeHandler(self.handler)
+        for target in self.loggers:
+            target.removeHandler(self.handler)
+        self.loggers[0].setLevel(self._level)
+        with _captures_lock:
+            try:
+                _captures.remove(self.buffer)
+            except ValueError:
+                pass
+            if self._streams is not None and not _captures:
+                sys.stdout, sys.stderr = self._streams

--- a/keyhac/skills/keyhac-action-authoring/SKILL.md
+++ b/keyhac/skills/keyhac-action-authoring/SKILL.md
@@ -132,12 +132,12 @@ paste into `~/.keyhac/config.py` instead:
 def configure(keymap):
     import open_issues                              # from extensions/
     action = open_issues.OpenIssues()
-    keymap.register_action("open-issues", action)   # list_actions / run_action
+    keymap.register_action("open-issues", action)   # list_actions / start_action
     kt["Fn-I"] = action                             # optional: bind a key
 ```
 
 `register_action` is what makes the action visible to `list_actions` and
-runnable by `run_action`; **a key binding alone leaves it invisible to both**,
+runnable by `start_action`; **a key binding alone leaves it invisible to both**,
 which costs you the run-read-fix loop. Reloading re-imports the module, so an
 edit is picked up without restarting Keyhac.
 

--- a/keyhac/skills/keyhac-action-authoring/references/api.md
+++ b/keyhac/skills/keyhac-action-authoring/references/api.md
@@ -127,10 +127,13 @@ raises rather than freezing the keyboard.
 
 ## Saying what happened
 
-Whatever the action logs or prints comes back to you from `run_action`, which
-is how you read your own failure instead of asking the operator to copy it out
-of a console window. `logger.info(...)`, `print(...)` and a logger made with
-the standard library all arrive.
+**Starting an action and collecting it are two calls.** `start_action` returns
+at once - these drive real applications and can take minutes - and
+`get_action_result` waits for the end and hands back everything the action
+logged or printed, with the traceback if it raised. That is how you read your
+own failure instead of asking the operator to copy it out of a console window.
+`logger.info(...)`, `print(...)` and a logger made with the standard library
+all arrive. `cancel_action` stops one, the same as the operator's Esc.
 
 **Shell out with `capture_output=True`.** It is the one thing that does *not*
 arrive on its own — a child process writes to a real file descriptor, so
@@ -142,8 +145,8 @@ subprocess.run(cmd, check=True, capture_output=True, text=True)
 ```
 
 Without it a failure reads "returned 1" with no reason, and the run-read-fix
-loop stops there. `run_action` says so explicitly when it happens, so if you
-see that note, add the argument.
+loop stops there. `get_action_result` says so explicitly when it happens, so
+if you see that note, add the argument.
 
 Log what a rerun would need, not that something broke: which selector, what was
 found instead, which item of how many.

--- a/keyhac/skills/keyhac-action-authoring/references/api.md
+++ b/keyhac/skills/keyhac-action-authoring/references/api.md
@@ -125,6 +125,29 @@ platform element method this API does not wrap. `starting()` and `finished()`
 already run there; `run()` does not, and must not block it — waiting there
 raises rather than freezing the keyboard.
 
+## Saying what happened
+
+Whatever the action logs or prints comes back to you from `run_action`, which
+is how you read your own failure instead of asking the operator to copy it out
+of a console window. `logger.info(...)`, `print(...)` and a logger made with
+the standard library all arrive.
+
+**Shell out with `capture_output=True`.** It is the one thing that does *not*
+arrive on its own — a child process writes to a real file descriptor, so
+nothing here can see it, and the only place its stderr survives is on the
+exception:
+
+```python
+subprocess.run(cmd, check=True, capture_output=True, text=True)
+```
+
+Without it a failure reads "returned 1" with no reason, and the run-read-fix
+loop stops there. `run_action` says so explicitly when it happens, so if you
+see that note, add the argument.
+
+Log what a rerun would need, not that something broke: which selector, what was
+found instead, which item of how many.
+
 ## A node is a snapshot
 
 `ui.window(...)`, `find`, `find_all` and a walked tree all hand back nodes that

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,6 +11,7 @@ import json
 import sys
 import os
 import stat
+import time
 import urllib.error
 import urllib.request
 
@@ -132,7 +133,8 @@ def test_a_non_jsonrpc_body_is_rejected(dispatcher):
 def test_tools_list_shape(dispatcher):
     tools = dispatcher.handle({"jsonrpc": "2.0", "id": 3,
                                "method": "tools/list"})["result"]["tools"]
-    assert {"describe_screen", "run_action", "list_windows"} <= {t["name"] for t in tools}
+    assert {"describe_screen", "start_action", "get_action_result",
+            "cancel_action", "list_windows"} <= {t["name"] for t in tools}
     for tool in tools:
         assert tool["description"] and tool["inputSchema"]["type"] == "object"
 
@@ -141,7 +143,7 @@ def test_a_failing_tool_reports_inside_the_result(dispatcher):
     """Not as a JSON-RPC error: the model is meant to read the failure and try
     again, which it cannot do if the transport swallows it."""
     reply = dispatcher.handle({"jsonrpc": "2.0", "id": 4, "method": "tools/call",
-                               "params": {"name": "run_action",
+                               "params": {"name": "start_action",
                                           "arguments": {"name": "absent"}}})
     assert "error" not in reply
     assert reply["result"]["isError"] is True
@@ -168,32 +170,27 @@ def test_find_elements_requires_a_criterion(registry):
         registry.call("find_elements", {})
 
 
-def test_run_action_returns_what_the_action_logged(registry):
+def test_an_action_reports_what_it_logged(registry):
     from keyhac.core import log
 
-    class Action:
-        def starting(self): pass
-        def run(self):
-            log.getLogger("Probe").info("did the thing")
-            return "ok"
-        def finished(self, result): pass
+    def run():
+        log.getLogger("Probe").info("did the thing")
+        return "ok"
 
-    registry.keymap.registered_actions["probe"] = Action()
-    assert "did the thing" in registry.call("run_action", {"name": "probe"})
+    output = _register(registry, run)
+    assert "did the thing" in output
+    assert "finished" in output
 
 
-def test_run_action_returns_the_traceback_rather_than_raising(registry):
+def test_a_failure_comes_back_as_a_traceback_rather_than_raising(registry):
     """The whole point of the tool: the model reads the failure itself."""
-    class Action:
-        def starting(self): pass
-        def run(self):
-            raise ValueError("selector matched nothing")
-        def finished(self, result): pass
+    def run():
+        raise ValueError("selector matched nothing")
 
-    registry.keymap.registered_actions["bad"] = Action()
-    output = registry.call("run_action", {"name": "bad"})
+    output = _register(registry, run, name="bad")
     assert "ValueError: selector matched nothing" in output
     assert "Traceback" in output
+    assert "failed" in output
 
 
 def test_reload_config_reloads(registry):
@@ -367,19 +364,21 @@ def test_a_native_window_keeps_the_truncation_note(registry):
     assert "enable_content_access" not in text
 
 
-# -- what run_action hands back (§15.3) --------------------------------------
+# -- what an action hands back (§15.3) --------------------------------------
 #
 # Three things reached the console window and not the model. Each of these
 # fails silently if it regresses: the tool still returns *something*, just
 # without the line that says what went wrong.
 
-def _register(registry, run):
+def _register(registry, run, name="probe"):
+    """Start an action and collect it, which is now two calls rather than one."""
     class Action:
         def starting(self): pass
         def finished(self, result): pass
     Action.run = staticmethod(run)
-    registry.keymap.registered_actions["probe"] = Action()
-    return registry.call("run_action", {"name": "probe"})
+    registry.keymap.registered_actions[name] = Action()
+    registry.call("start_action", {"name": name})
+    return registry.call("get_action_result", {"name": name, "wait": 20})
 
 
 def test_print_reaches_the_model(registry):
@@ -477,3 +476,127 @@ def test_a_long_run_is_bounded_and_says_it_was_truncated(registry):
     assert len(output) < MAX_CAPTURE * 1.5
     assert "characters dropped" in output
     assert "THE LAST LINE" in output, "the tail is where the failure is"
+
+
+# -- the asynchronous shape --------------------------------------------------
+#
+# Starting and collecting are separate because the transport answers one
+# message per request and §2's actions run for minutes. These pin the parts
+# that only exist because of that.
+
+def _slow_action(registry, name="slow"):
+    import threading as t
+    gate = t.Event()
+
+    class Action:
+        def starting(self): pass
+        def finished(self, result): pass
+        def run(self):
+            print("started working")
+            gate.wait(20)
+            print("done working")
+
+    registry.keymap.registered_actions[name] = Action()
+    return gate
+
+
+def test_start_action_returns_before_the_action_finishes(registry):
+    """The property the whole shape exists for: a call that waited for the end
+    is a call that times out for exactly the workload this serves."""
+    gate = _slow_action(registry)
+    reply = registry.call("start_action", {"name": "slow"})
+    assert "started" in reply
+    assert "slow" in registry.call("list_actions", {})
+    assert "RUNNING" in registry.call("list_actions", {})
+    gate.set()
+    registry.call("get_action_result", {"name": "slow", "wait": 20})
+
+
+def test_still_running_is_an_answer_not_a_timeout(registry):
+    gate = _slow_action(registry)
+    registry.call("start_action", {"name": "slow"})
+    reply = registry.call("get_action_result", {"name": "slow", "wait": 0})
+    assert "still running" in reply
+    assert "started working" in reply, "output so far comes back too"
+    assert "again" in reply, "and it says what to do about it"
+    gate.set()
+    registry.call("get_action_result", {"name": "slow", "wait": 20})
+
+
+def test_a_waiting_collect_returns_as_soon_as_it_ends(registry):
+    """Waiting rather than polling is what keeps a fast action fast: two round
+    trips, no added latency."""
+    import threading as t
+    import time as clock
+
+    gate = _slow_action(registry)
+    registry.call("start_action", {"name": "slow"})
+    t.Timer(0.2, gate.set).start()
+    began = clock.monotonic()
+    reply = registry.call("get_action_result", {"name": "slow", "wait": 20})
+    assert clock.monotonic() - began < 5, "it waited out the full timeout"
+    assert "done working" in reply
+
+
+def test_cancel_action_stops_it(registry):
+    """The model can stop what it started - refusing that while allowing
+    starting would be the odd asymmetry."""
+    from keyhac.core.action import ActionCancelled, ThreadedAction
+
+    class Slow(ThreadedAction):
+        def __init__(self):
+            self.entered = __import__("threading").Event()
+        def run(self):
+            self.entered.set()
+            from keyhac.core.wait import wait_for
+            wait_for(lambda: False, timeout=20, message="never", interval=0.01)
+
+    action = Slow()
+    registry.keymap.registered_actions["slow2"] = action
+    registry.call("start_action", {"name": "slow2"})
+    assert action.entered.wait(5)
+    assert "asked" in registry.call("cancel_action", {"name": "slow2"})
+    assert "cancelled" in registry.call("get_action_result",
+                                        {"name": "slow2", "wait": 20})
+
+
+def test_collecting_an_action_that_never_ran(registry):
+    class Action:
+        def starting(self): pass
+        def run(self): pass
+        def finished(self, result): pass
+
+    registry.keymap.registered_actions["idle"] = Action()
+    assert "has not been run" in registry.call("get_action_result",
+                                               {"name": "idle", "wait": 0})
+    assert "not run yet" in registry.call("list_actions", {})
+
+
+def test_starting_one_that_is_already_running_says_so(registry):
+    gate = _slow_action(registry)
+    registry.call("start_action", {"name": "slow"})
+    assert "already running" in registry.call("start_action", {"name": "slow"})
+    gate.set()
+    registry.call("get_action_result", {"name": "slow", "wait": 20})
+
+
+def test_an_unrelated_print_does_not_land_in_a_running_action(registry):
+    """A run lasts minutes. A global stdout tee spent all of them absorbing
+    every unrelated print in the process into whichever action happened to be
+    running - which the first end-to-end run showed as an action's record
+    quoting the script that started it."""
+    import threading as t
+
+    gate = _slow_action(registry)
+    registry.call("start_action", {"name": "slow"})
+    time.sleep(0.1)
+
+    elsewhere = t.Thread(target=lambda: print("NOT THE ACTION'S OUTPUT"))
+    elsewhere.start()
+    elsewhere.join(5)
+
+    peek = registry.call("get_action_result", {"name": "slow", "wait": 0})
+    assert "started working" in peek, "the action's own print is captured"
+    assert "NOT THE ACTION'S OUTPUT" not in peek
+    gate.set()
+    registry.call("get_action_result", {"name": "slow", "wait": 20})

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,6 +8,7 @@ the result so the model can read it.
 """
 
 import json
+import sys
 import os
 import stat
 import urllib.error
@@ -364,3 +365,115 @@ def test_a_native_window_keeps_the_truncation_note(registry):
     text = registry.call("describe_screen", {})
     assert "raise max_nodes/max_depth" in text
     assert "enable_content_access" not in text
+
+
+# -- what run_action hands back (§15.3) --------------------------------------
+#
+# Three things reached the console window and not the model. Each of these
+# fails silently if it regresses: the tool still returns *something*, just
+# without the line that says what went wrong.
+
+def _register(registry, run):
+    class Action:
+        def starting(self): pass
+        def finished(self, result): pass
+    Action.run = staticmethod(run)
+    registry.keymap.registered_actions["probe"] = Action()
+    return registry.call("run_action", {"name": "probe"})
+
+
+def test_print_reaches_the_model(registry):
+    """The shipped config.py template teaches print() on the same line as the
+    logger. It reached the console window and stopped there."""
+    assert "printed this" in _register(registry, lambda: print("printed this"))
+
+
+def test_print_still_reaches_the_console(registry):
+    """Teed, not redirected: the operator watching the console window is not
+    who this change was for, and must not lose anything."""
+    import sys
+    seen = []
+
+    class Console:
+        def write(self, text): seen.append(text); return len(text)
+        def flush(self): pass
+
+    original = sys.stdout
+    sys.stdout = Console()
+    try:
+        _register(registry, lambda: print("both places"))
+    finally:
+        sys.stdout = original
+    assert any("both places" in text for text in seen)
+
+
+def test_a_logger_outside_the_keyhac_tree_is_captured(registry):
+    """What getLogger(__name__) produces in a module under extensions/."""
+    import logging as stdlib_logging
+
+    def run():
+        stdlib_logging.getLogger("my_extension").info("from an extension")
+
+    assert "from an extension" in _register(registry, run)
+
+
+def test_the_documented_logger_is_still_captured(registry):
+    """`keyhac` is configured with propagate=False, so a root-only handler sees
+    none of it - the regression this pins."""
+    from keyhac.core import log
+
+    def run():
+        log.getLogger("Probe").info("through keyhac's own logger")
+
+    assert "through keyhac's own logger" in _register(registry, run)
+
+
+def test_nothing_is_captured_twice(registry):
+    from keyhac.core import log
+
+    def run():
+        log.getLogger("Probe").info("once please")
+
+    assert _register(registry, run).count("once please") == 1
+
+
+def test_a_failed_subprocess_hands_over_its_stderr(registry):
+    """No stream wrapper can see this: the child writes to the real file
+    descriptor, not to Python's sys.stderr. It survives only on the exception,
+    and only when the action asked for it."""
+    import subprocess
+
+    def run():
+        subprocess.run([sys.executable, "-c", "import sys; sys.stderr.write('the child complained'); sys.exit(3)"],
+                       check=True, capture_output=True, text=True)
+
+    output = _register(registry, run)
+    assert "the child complained" in output
+
+
+def test_a_subprocess_run_without_capture_says_so(registry):
+    """Better than silence: "returned 1" with no reason is where the loop
+    stalls, and the fix is a line in the action rather than a mystery."""
+    import subprocess
+
+    def run():
+        subprocess.run([sys.executable, "-c", "import sys; sys.exit(4)"], check=True)
+
+    output = _register(registry, run)
+    assert "capture_output=True" in output
+
+
+def test_a_long_run_is_bounded_and_says_it_was_truncated(registry):
+    """A run logging a line per row over hundreds of rows would otherwise fill
+    a context window with the middle of its own progress."""
+    from keyhac.mcp.tools import MAX_CAPTURE
+
+    def run():
+        for index in range(2000):        # ~100k characters, fixed
+            print(f"row {index} " + "x" * 40)
+        print("THE LAST LINE")
+
+    output = _register(registry, run)
+    assert len(output) < MAX_CAPTURE * 1.5
+    assert "characters dropped" in output
+    assert "THE LAST LINE" in output, "the tail is where the failure is"


### PR DESCRIPTION
Closes **§15.3**, and **§15.4** arrives with it. Two commits, because the
second could not have been guessed from the first.

## 1. What comes back (§15.3)

The tool exists so a model reads its own failure instead of the operator
copying tracebacks out of a console window. Three kinds of output reached that
window and stopped there. Two now come back:

- **`print()`** — which the shipped `config.py` template teaches on the same
  line as the logger.
- **Loggers outside the `keyhac` tree** — `getLogger(__name__)` in a module
  under `extensions/`, and any library the action imports.
- **Subprocess stderr** — and this one *cannot* be captured. A child writes to
  a real file descriptor, not to Python's `sys.stderr`. It survives only on the
  exception, so `CalledProcessError.stderr` is surfaced when present **and its
  absence is reported when not** — that note is the fix, since "returned 1"
  with no reason is where the loop stalls. The skill now says to shell out with
  `capture_output=True`.

Two things the plan did not anticipate:

- **The handler must sit on both root and `keyhac`.** `core/log.py` sets
  `propagate=False`, so moving it to root — the obvious reading of §15.3 —
  captured *nothing* from the documented `getLogger()`. The tests caught it,
  and only in a full-file run.
- **Streams are teed, not redirected.** `redirect_stdout` would take `print()`
  away from the console window.

## 2. Starting and collecting become two calls

The synchronous shape could not survive the executor work. §2's actions run for
minutes; the endpoint answers one message per request with no stream for
progress; and the bridge caps a call at 60s. So `run_action` returned a
transport error for exactly the workload it exists to serve, while the action
carried on invisibly.

```
list_actions        what exists, what is running, how each last ended
start_action        starts it, returns at once
get_action_result   waits up to `wait` seconds, returns what it did
cancel_action       stops it — the same thing the operator's Esc does
```

`get_action_result` **waits** rather than returning immediately, which keeps a
fast action fast: two round trips, no added latency. "Still running" is a normal
answer rather than a timeout.

Async by design, not as a fallback. Blocking-briefly-then-polling was
considered and is worse: two reply shapes selected by how fast the action
happened to be, and a fallback path that only runs when something is slow and
therefore rots.

**Renamed** because `run_action` means "do it and tell me the result" in every
other tool API, and the name is the shortest, most-read part of the contract —
believed over any description saying otherwise. §14's recorded failure in
another costume.

### §15.4 came with it

Splitting the call means a run's output must live somewhere retrievable. Once
that store exists, the thing that fills it is `cancellable()` — the same seam
Esc uses — so a **key-triggered** run records itself identically. *"The PDF one
failed this morning"* is now `get_action_result("print-tabs")`. Memory only,
one run per action: a record holds window titles and element names, which is
§9's material.

## What the first end-to-end run caught

The stdout tee was **global while any action ran** — and a run lasts minutes,
so it absorbed every unrelated print in the process. The demo showed an
action's record quoting the script that started it. Now thread-scoped, which is
exact rather than merely narrower: an action's own `print()` happens on the
thread running its `run()`. Log records stay global, because `starting()` and
`finished()` run on the loop thread.

Also caught: the run record was keyed by reversing the action out of the Keymap
*singleton*, not the registry it came from.

## Checks

- 396 passed, 16 skipped
- Calibrated by breaking each capability in turn: root-only capture 3 failures,
  no tee 2, no subprocess detail 1, unbounded 1
- Driven end to end — start, list, peek while running, cancel, collect, and the
  same for a key-triggered run collected afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)