### PR TITLE
Move to Python 3.14, and pin puikit to the release that has the IME fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ reviewed one-off.
 
 ## Key decisions (rationale in doc/dev/)
 
-1. **Languages**: Python 3.13 for everything at runtime. Platform bindings via
+1. **Languages**: Python 3.14 for everything at runtime. Platform bindings via
    **ctypes** (Windows) and **PyObjC** (macOS) — no custom compiled extension modules.
    The only non-Python code is a tiny PEP 587 embedding **launcher** per OS, needed
    for packaging and a stable app identity (macOS Accessibility permission is granted
@@ -101,7 +101,7 @@ tools/         # icon pipeline, release scripts, hook_echo diagnostic
 - PuiKit changes are developed in `../puikit` and must respect its additive API
   policy (new capability flags default off; new `Backend` methods get base
   no-op/raise). **Always on a feature branch with a pull request — never commit
-  directly to its main.** Keyhac2 depends on `puikit>=1.0.8` from PyPI; an editable
+  directly to its main.** Keyhac2 depends on `puikit>=1.0.10` from PyPI; an editable
   checkout is for puikit development only (set `PUIKIT_DIR` in gitignored
   `Makefile.local`; `make install-puikit` switches an existing venv).
 - `../keyhac-win` and `../keyhac-mac` are **read-only** references. Never modify them.

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,18 @@ else ifeq ($(OS),Windows_NT)
     IS_WINDOWS := 1
 endif
 
-# Keyhac 2 targets Python 3.13 (the version embedded in the shipped app).
+# Keyhac 2 targets Python 3.14 (the version embedded in the shipped app).
 ifeq ($(IS_WINDOWS),1)
-    PY_ON_PATH := $(shell command -v python3.13 2>/dev/null)
+    PY_ON_PATH := $(shell command -v python3.14 2>/dev/null)
     ifneq ($(strip $(PY_ON_PATH)),)
-        PYTHON := python3.13
+        PYTHON := python3.14
     else
         PYTHON := py
     endif
     VENV_PYTHON := $(VENV)/Scripts/python.exe
     VENV_PIP := $(VENV)/Scripts/pip.exe
 else
-    PYTHON := python3.13
+    PYTHON := python3.14
     VENV_PYTHON := $(VENV)/bin/python
     VENV_PIP := $(VENV)/bin/pip
 endif

--- a/doc/dev/overview.md
+++ b/doc/dev/overview.md
@@ -17,7 +17,7 @@ Two independent implementations preceded Keyhac 2:
 |---|---|---|
 | Host / UI | Thin C++ launcher; UI in Python on **ckit** (author's Win32 C++ toolkit) | **Swift/SwiftUI** menu-bar app; C++ `PythonBridge` embeds CPython |
 | Input layer | **pyauto** (author's C++ extension): `WH_KEYBOARD_LL`, `SendInput`, Win32 window API | Swift: `CGEventTap`, `CGEventPost`, AXUIElement |
-| Python | 3.13 embedded (PEP 587, isolated) | 3.13 embedded (PEP 587, isolated) |
+| Python | 3.14 embedded (PEP 587, isolated) | 3.14 embedded (PEP 587, isolated) |
 | Config API | camelCase (`defineWindowKeymap`, `InputKeyCommand`, …) | snake_case (`define_keytable`, `ThreadedAction`, …) — newer, cleaner |
 | Feature set | Larger (mouse, macro, balloons, themes, migemo, tray menu…) | Smaller but modernized (UIElement/AX automation, focus paths, chooser) |
 
@@ -64,7 +64,7 @@ Short answers; each links to the full analysis.
 
 ### Q1. What languages do we use other than Python?
 
-**Almost none at runtime.** Python 3.13 everywhere; Windows OS access via **ctypes**
+**Almost none at runtime.** Python 3.14 everywhere; Windows OS access via **ctypes**
 (as PuiKit's Windows backend already proves viable, including COM), macOS via **PyObjC**
 (Quartz/ApplicationServices provide `CGEventTap` and `AXUIElement`). The only non-Python
 code is a **tiny embedding launcher per OS** (~150 lines of C/C++ using the PEP 587

--- a/doc/dev/packaging.md
+++ b/doc/dev/packaging.md
@@ -4,7 +4,7 @@
 
 | Layer | Language | Size | Why |
 |---|---|---|---|
-| Application (engine, UI, platform bindings) | Python 3.13 | ~everything | ctypes covers Win32 (PuiKit's Windows backend proves it incl. COM/Direct2D); PyObjC covers Quartz/AX/AppKit |
+| Application (engine, UI, platform bindings) | Python 3.14 | ~everything | ctypes covers Win32 (PuiKit's Windows backend proves it incl. COM/Direct2D); PyObjC covers Quartz/AX/AppKit |
 | Embedding launcher, Windows (`Keyhac.exe`) | C | ~150 lines | PEP 587 `PyConfig` isolated init, module search paths. Also: exe icon, DPI manifest. |
 | Embedding launcher, macOS (`Keyhac.app` main) | Objective-C | ~150 lines | Same PEP 587 pattern. A real bundle executable is **required** so the Accessibility permission attaches to a stable identity — running under a generic `python3` would grant the permission to that interpreter, not to Keyhac. |
 | Build scripts | PowerShell / shell / Python | | `windows_app/build.ps1`, `macos_app/build.sh`, `tools/` |
@@ -102,7 +102,7 @@ odd one out: it submits to the Microsoft Store, not the GitHub Release. Supporti
 Release artifacts per version: `Keyhac-<ver>-macos.dmg`, `Keyhac-<ver>-win64.zip`,
 `keyhac-action-authoring-skill.zip` (attached to the GitHub Release), and the
 `keyhac` wheel on PyPI. PuiKit is
-versioned/released independently on PyPI; Keyhac2 pins a minimum (`puikit>=1.0.8`).
+versioned/released independently on PyPI; Keyhac2 pins a minimum (`puikit>=1.0.10`).
 
 **`release-skill` is not optional the way it looks.** The skill bundle is the
 only way a user can obtain the authoring skill — `make skill-bundle` needs the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,18 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Utilities",
 ]
 dependencies = [
-    # 1.0.8 is the first release with every puikit API/fix keyhac uses:
-    # set_tray(image=) (PR #82), main-window visibility (PR #84), and the
-    # LogView sized-font clip fix the 11pt console log needs (PR #86). To
-    # develop against a local checkout, set PUIKIT_DIR (see Makefile).
-    "puikit>=1.0.8",
+    # 1.0.10 is the first release with every puikit API/fix keyhac uses:
+    # set_tray(image=) (PR #82), main-window visibility (PR #84), the LogView
+    # sized-font clip fix the 11pt console log needs (PR #86), and per-window
+    # IME input contexts (PR #90) - without that last one the chooser's filter
+    # box accepts ASCII and never composes Japanese, which is issue #20 and is
+    # what doc/dev/testing.md's IME pass verifies. To develop against a local
+    # checkout, set PUIKIT_DIR (see Makefile).
+    "puikit>=1.0.10",
     'pyobjc-framework-Cocoa>=10; sys_platform == "darwin"',
     'pyobjc-framework-Quartz>=10; sys_platform == "darwin"',
     'pyobjc-framework-ApplicationServices>=10; sys_platform == "darwin"',


### PR DESCRIPTION
## The pin

`puikit>=1.0.8`, with a comment claiming 1.0.8 was *"the first release with
every puikit API/fix keyhac uses"*. That stopped being true when per-window IME
input contexts landed in **1.0.10** (puikit PR #90) — without them the
chooser's filter box accepts ASCII and never composes Japanese, which is issue
#20.

The concrete harm is worth naming: `doc/dev/testing.md` records the IME pass as
**passed 2026-08-07**, but that was against a local checkout. Anyone installing
from PyPI got a build that could not do the thing the test record said had been
tested.

Now `>=1.0.10`, with the comment saying which fix and why. CLAUDE.md and
packaging.md restated the old number and are updated too.

## Python 3.14

**Verified before changing anything**, in a throwaway venv so the working one
was never at risk: 3.14.3, `pyobjc` and `puikit` install clean, 396 passed.
Then the real venv was rebuilt through `make venv` and the whole set re-run on
it — suite, `api-reference-check`, skill evals, bundle. All green.

**The macOS bundle builder needed no change, and the reason is worth
recording because it looked like a blocker.** 3.14 is present here as a
Homebrew build, not a python.org framework, and `build.sh` embeds a Python into
the app. But it already detects both, keying on `/Python.framework/Versions/`
appearing in the base prefix — which Homebrew's layout satisfies, and its own
comment says so. The version was never hardcoded there; it is read from the
venv.

`requires-python` **deliberately stays `>=3.12`**. It is a floor, not a target:
nothing here uses newer syntax, the shipped app embeds its own interpreter so
bundle users are unaffected either way, and narrowing it would break pip
installs for people on 3.13 to no purpose. 3.14 joins the classifiers rather
than replacing what is there — say if you would rather it were narrowed.

## Checks

- 396 passed, 16 skipped on 3.14.3 — first in a throwaway venv, then in the
  rebuilt `make venv` one
- `make api-reference-check` clean; skill evals pass; bundle builds
- The existing venv was rebuilt: it is now 3.14-based, with the editable puikit
  preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)