### PR TITLE
Say that a patch release can move the AI surface, because 2.2.1 does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,12 @@ identity and handle lifetime are still open ([doc/dev/ai-integration.md](doc/dev
 §11), and settling them may break actions. Do not treat that surface as frozen,
 and do not extend the experimental marker to anything else.
 
+**2.2.x is the line this feature is being built in**, so a patch release may
+break the AI surface - 2.2.1 removed `enable_mcp_server()` and replaced
+`run_action` with three tools. The version number therefore does not carry that
+warning, which means the release notes have to: lead with what breaks, every
+time, for as long as the marker is up.
+
 What remains is tracked in the GitHub issues: the deferred features (themes/fonts,
 i18n, migemo, rich clipboard formats, macOS ISO layout, balloon help UI). The
 genuinely-interactive verification passes are through (issue #10, closed), but

--- a/doc/action-api.md
+++ b/doc/action-api.md
@@ -10,8 +10,10 @@ Generated from the docstrings. For how to *write* an action, the authoring
 skill in `keyhac/skills/keyhac-action-authoring/` is the procedural half, and
 `examples/actions/` holds working ones.
 
-> **Experimental.** This surface may change in ways a minor release normally
-> would not, and an upgrade may require editing actions you have written. The
+> **Experimental.** This surface may change in ways a release number normally
+> promises it will not — 2.2.x is the line this feature is being built in, so
+> even a patch release can move it — and an upgrade may require editing
+> actions you have written. The
 > unsettled part is `UINode` itself — how an element is identified, and how
 > long a node you are holding stays valid — which is the shape everything
 > below is built on. The rest of Keyhac's API is not affected; see

--- a/doc/ai-integration.md
+++ b/doc/ai-integration.md
@@ -39,6 +39,12 @@ open and can run the actions you register. See [Security](#security).
 > identified, and how long a node you are holding stays valid — is not
 > settled, and it is the shape everything else is built on.
 >
+> **And it is not only minor releases. The 2.2.x line is where this feature is
+> being built**, so a *patch* release in it can change the AI surface too —
+> 2.2.1 removed `keymap.enable_mcp_server()` and replaced `run_action` with
+> three tools. Read these notes before upgrading if you have turned it on.
+> Everything outside this feature keeps what a patch number promises.
+>
 > **Why it is shipped anyway:** it is off by default and additive, so it costs
 > nothing to anyone who does not enable it, and the shape will be settled by
 > people writing real actions rather than by more design. If you write some,

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -340,8 +340,9 @@ action drives somebody else's UI, and only `UINode`, `WaitTimeout` and
 surface, and `keyhac/skills/keyhac-action-authoring/` for how to write one.
 
 **This surface is experimental** and the rest of this document is not: it may
-change in ways a minor release normally would not, and an upgrade may require
-editing actions you have written. Everything else here — key tables, clipboard
+change in ways a release number normally promises it will not — 2.2.x is the
+line this feature is being built in, so even a patch release can move it — and
+an upgrade may require editing actions you have written. Everything else here — key tables, clipboard
 history, macros, window control — keeps the stability you expect from a 2.x
 release. [AI Integration](ai-integration.md) says what is unsettled and
 what would settle it.

--- a/tools/generate_api_reference.py
+++ b/tools/generate_api_reference.py
@@ -128,8 +128,10 @@ Generated from the docstrings. For how to *write* an action, the authoring
 skill in `keyhac/skills/keyhac-action-authoring/` is the procedural half, and
 `examples/actions/` holds working ones.
 
-> **Experimental.** This surface may change in ways a minor release normally
-> would not, and an upgrade may require editing actions you have written. The
+> **Experimental.** This surface may change in ways a release number normally
+> promises it will not — 2.2.x is the line this feature is being built in, so
+> even a patch release can move it — and an upgrade may require editing
+> actions you have written. The
 > unsettled part is `UINode` itself — how an element is identified, and how
 > long a node you are holding stays valid — which is the shape everything
 > below is built on. The rest of Keyhac's API is not affected; see


### PR DESCRIPTION
The experimental marker said the additive-only rule — *"a minor release only
adds"* — does not apply to this feature. It did not say **patch** releases can
move it either, and 2.2.1 is where that becomes concrete: `enable_mcp_server()`
is gone and `run_action` is replaced by three tools, so a `config.py` written
against 2.2.0 **fails to load** after what its version number calls a bug-fix
release.

2.2.x is deliberately the line this feature is being built in. The consequence
is that **the version number stops carrying the warning**, and something else
has to.

Four places now say so, each naming 2.2.1's two removals rather than warning in
the abstract — *"may change"* is what everyone ignores:

- `doc/ai-integration.md` — the full marker
- `doc/action-api.md` — via `ACTION_HEADER` in the generator, so it survives
  the next `make api-reference`
- `doc/configuration.md` — the short form
- `CLAUDE.md` — for coding agents

`CLAUDE.md` also carries the obligation that falls out of it: **the release
notes have to lead with what breaks, every time, for as long as the marker is
up.** Written down because it is the kind of rule that is obvious while the
decision is fresh and invisible three releases later.

What is *not* being widened: everything outside this feature keeps what a patch
number promises, and all four say that in the same breath.

## Checks

- 396 passed, 16 skipped
- `make api-reference-check` clean — the generated header regenerates to match
- Bundle rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)