### PR TITLE
Six bugs in the action-authoring surface, found writing an action with it

### DIFF
--- a/doc/action-api.md
+++ b/doc/action-api.md
@@ -85,9 +85,18 @@ Ask a Chromium or Electron application to expose its content.
 focused() → UINode | None
 ```
 
-The element with keyboard focus, as a node. 
+The element with keyboard focus right now, as a node. 
 
 The cheapest root there is: a key binding already told you which application and which field the user meant (design document §3.2). 
+
+**Asked each time, not remembered.** This used to hand back `keymap.focus`, which is a snapshot taken while a key was being dispatched - so an action that closed a window and waited for focus to land somewhere else never saw it move, and kept being handed the destroyed element, or the application that no longer had a window. Polling did not help, because polling produces no keystrokes and only a keystroke refreshed it (issue #44). 
+
+`keymap.focus` stays what it was, on purpose. Deciding which key table applies to a keystroke needs the focus *that keystroke* was aimed at, and re-reading it there would race the key it is dispatching. The two are different questions; this is the one an action is asking. 
+
+
+
+**Returns:**
+  The focused element, or None when nothing has focus or the  platform could not say. None is an answer - a stale element that  fails every attribute read is not. 
 
 ---
 

--- a/doc/config-api.md
+++ b/doc/config-api.md
@@ -24,28 +24,6 @@ One Keymap exists per Keyhac process.  The configuration file receives it as ``c
 
 ---
 
-#### <kbd>property</kbd> Keymap.action_authoring_allowed
-
-Whether the endpoint may write into ``extensions/`` right now. 
-
-Off unless the operator switched it on, off again when the window in :data:`_AUTHORING_WINDOW` runs out, and off after a restart - deliberately not persisted, because forgetting to switch it back off is the failure this is shaped around. 
-
-The deadline *is* the state: expiry is decided here rather than by a timer thread, so a headless run with nothing polling still refuses a late write, and there is no timer to cancel at shutdown. 
-
-lazydocs: ignore 
-
----
-
-#### <kbd>property</kbd> Keymap.action_authoring_lapsed
-
-Whether a write window ran out, as opposed to never being opened. 
-
-One refusal at the endpoint, two different things for the operator to do about it - so the tool that refuses says which one happened.  A timeout that reads as "this feature does not work" is the cost this exists to avoid. 
-
-lazydocs: ignore 
-
----
-
 #### <kbd>property</kbd> Keymap.clipboard
 
 The OS clipboard - get_text() / set_text(), or None if unwired. 
@@ -57,6 +35,14 @@ The history's provider, exposed directly because actions that paste need to read
 #### <kbd>property</kbd> Keymap.clipboard_history
 
 The ClipboardHistory object (None while running without one, e.g. under --no-ui). 
+
+---
+
+#### <kbd>property</kbd> Keymap.config_path
+
+The configuration script this run loads. 
+
+lazydocs: ignore 
 
 ---
 

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -1443,8 +1443,20 @@ rather than being the return value of the call that started it.
 Which is what this section asked for. Once that store exists, the entry point
 that fills it is `ThreadedAction.cancellable()` — the same seam Esc uses — so a
 run started by a **key press** records itself identically. "The PDF one failed
-this morning" is now `get_action_result("print-tabs")`, with the traceback, the
-subprocess stderr, and how far it got.
+this morning" is now
+`get_action_result("save_pages_as_pdf.SavePagesAsPdf")`, with the traceback,
+the subprocess stderr, and how far it got.
+
+"Identically" took a second pass to become true. Both paths went through
+`cancellable()`, but only one of them was *given* a name: the MCP tool passed
+`module.Class` and a key press fell back to `repr(self)`, so the records landed
+in the same dictionary under two keys and a lookup by name never found the
+operator's run — it returned the previous MCP one, unchanged, while
+`list_actions` said "not run yet" about an action they had just pressed
+(issue #42). The name is derived from the class now, which lands on the same
+string for anything in `extensions/`; `cancel_action` looks in
+`ThreadedAction._running` as well as the loader's cache, so the stop button
+reaches an action it did not start.
 
 The open questions answered themselves, mostly conservatively:
 

--- a/keyhac/_config.py
+++ b/keyhac/_config.py
@@ -365,17 +365,19 @@ def configure(keymap):
     # custom_condition_func receives the portable Focus object: app_name,
     # window_title, class_name (Windows), path, and element - the focused
     # element in the OS's own vocabulary.
+    #
+    # Name the applications.  The tempting shortcut - "a terminal is whatever
+    # focuses a text area" - is wrong in both directions, and was shipped here
+    # for a while: on macOS an editor pane and a chat box are AXTextArea too,
+    # while VS Code's own integrated terminal is an AXTextField.  So the
+    # binding below took over every text box on the machine and did nothing in
+    # a real terminal.  A control's role says how it behaves, never what it is
+    # for; if you do reach for focus.element, check what your terminal
+    # actually reports in the console's "Focus path" field first.
     def is_terminal(focus):
-        if focus.app_name in ("Terminal", "iTerm2", "WindowsTerminal", "cmd",
-                              "powershell", "pwsh"):
-            return True
-        # Element attributes differ per OS: AX names on macOS, UI Automation
-        # names on Windows.  An unknown name simply reads back as None.
-        element = focus.element
-        if element is None:
-            return False
-        role = element.get_attribute_value("AXRole" if mac else "ControlType")
-        return role in ("AXTextArea", "Document")
+        return focus.app_name in ("Terminal", "iTerm2", "WezTerm", "Alacritty",
+                                  "kitty", "WindowsTerminal", "cmd",
+                                  "powershell", "pwsh")
 
     kt_terminal = keymap.define_keytable(custom_condition_func=is_terminal)
     kt_terminal[f"{LEADER}-K"] = "Ctrl-K"     # clear, rather than "Down"

--- a/keyhac/core/action.py
+++ b/keyhac/core/action.py
@@ -11,6 +11,8 @@ come back for it (keyhac/core/capture.py).
 """
 
 import contextlib
+import os
+import sys
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor
@@ -218,11 +220,10 @@ class ThreadedAction:
             ThreadedAction._running.add(self)
 
         # `name` when the caller has one - the MCP tool, which was handed the
-        # class's `module.Class` to look this up by. A key press has no name to
-        # give, so the record is filed under the repr; it is still reachable by
-        # Esc and still reports itself to the console, which is what a key-press
-        # run needs.
-        self._run_record = capture.start_run(name or repr(self))
+        # class's `module.Class` to look this up by. A key press has none to
+        # give, so it is derived from the class, which lands on the same string
+        # for anything defined in `extensions/`.
+        self._run_record = capture.start_run(name or self._run_name())
         try:
             with capture.capture(self._run_record.output):
                 yield self
@@ -241,6 +242,44 @@ class ThreadedAction:
             _current.action = None
             with ThreadedAction._running_lock:
                 ThreadedAction._running.discard(self)
+
+    def _run_name(self) -> str:
+        """What to file this action's run under when nobody named it.
+
+        `module.Class` for anything defined in `extensions/` - the same string
+        `start_action` was handed and the same one `get_action_result` and
+        `list_actions` look up. They used to disagree: a key press filed its
+        run under `repr(self)` and the MCP tool under `module.Class`, so a run
+        the operator had just triggered read back as "not run yet" and the
+        previous MCP result was returned in its place, unchanged (issue #42).
+        Nothing was wrong with the key, the hook or the permissions, which is
+        what made it expensive to chase.
+
+        Everything else keeps its repr, which carries what a bare class name
+        cannot: `LaunchApplication("Terminal.app")` says which application, and
+        two bindings differing only in their arguments stay two records.
+        `keyhac.core.action.LaunchApplication` would say neither.
+
+        lazydocs: ignore
+        """
+        cls = type(self)
+        module = sys.modules.get(cls.__module__)
+        path = getattr(module, "__file__", None)
+        if not path:
+            return repr(self)
+        from keyhac.core.keymap import Keymap
+        keymap = Keymap.get_instance()
+        # None in library and test use, where there is no configuration
+        # directory to be inside of.
+        directory = getattr(keymap, "extensions_dir", None) if keymap else None
+        if not directory:
+            return repr(self)
+        try:
+            prefix = os.path.realpath(directory) + os.sep
+            inside = os.path.realpath(path).startswith(prefix)
+        except OSError:
+            return repr(self)
+        return f"{cls.__module__}.{cls.__qualname__}" if inside else repr(self)
 
     def _done_callback(self, future):
         # add_done_callback fires on the pool thread; hand finished() back to

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -56,6 +56,56 @@ _MODIFIER_BITS = (
 _AUTHORING_WINDOW = 60 * 60
 
 
+#: ``{module name: (real path, source mtime)}`` for every module loaded out of
+#: ``extensions/``.  Process-wide rather than per-Keymap because ``sys.modules``
+#: is, and the question this answers is about that one dictionary: is the copy
+#: in it still the file on disk?  Written by ``_stamp_extensions`` after a
+#: configuration load and by the loader that imports a module to run it; read by
+#: ``_loaded_extension``.
+_extension_stamps: dict[str, tuple[str, int]] = {}
+
+
+def _source_mtime(path: str) -> int:
+    """A file's mtime in nanoseconds, or -1 when it cannot be read.
+
+    Nanoseconds because the whole-second resolution of a ``.pyc`` header is
+    what made issue #41 possible; nothing here should repeat that.
+    """
+    try:
+        return os.stat(path).st_mtime_ns
+    except OSError:
+        return -1
+
+
+def _extension_files(extensions_dir: str):
+    """``(module name, real path)`` for each loaded module under the directory.
+
+    lazydocs: ignore
+    """
+    prefix = os.path.realpath(extensions_dir) + os.sep
+    for name, module in list(sys.modules.items()):
+        path = getattr(module, "__file__", None)
+        if not path:
+            continue
+        path = os.path.realpath(path)
+        if path.startswith(prefix):
+            yield name, path
+
+
+def stamp_extension_module(module_name: str, path: str) -> None:
+    """Record that `module_name` was just loaded from `path`.
+
+    For the one importer that is not a plain ``import``: `start_action` loads a
+    module by file location, and what it leaves in ``sys.modules`` has to be
+    recognizable as current afterwards, or the next start re-imports it and
+    splits the module in two again (issue #40).
+
+    lazydocs: ignore
+    """
+    _extension_stamps[module_name] = (os.path.realpath(path),
+                                      _source_mtime(path))
+
+
 def _key_text(key: KeyCondition) -> str:
     """A KeyCondition spelled the way a `config.py` would write it.
 
@@ -229,6 +279,11 @@ class Keymap:
                 print()
                 logger.error(f"Loading configuration script failed:\n{traceback.format_exc()}")
                 return
+            finally:
+                # In `finally` because a config that raised half way through
+                # still imported everything above the line that raised, and
+                # those modules are in sys.modules either way.
+                self._stamp_extensions(extensions_dir)
 
             self._warn_unreachable_modifiers()
 
@@ -236,7 +291,7 @@ class Keymap:
     def _prepare_extensions(extensions_dir: str) -> None:
         """Make ``~/.keyhac/extensions`` importable, and re-importable.
 
-        Two things, and the second is the one that bites.
+        Three things, and only the first is obvious.
 
         **On sys.path**, so a config can be split into modules -- which is what
         the directory is created for, and what doc/configuration.md has always
@@ -252,6 +307,20 @@ class Keymap:
         read, and the run reports success against stale code.  That failure is
         silent by construction, and it lands squarely on the edit-reload-run
         loop this directory exists to serve.
+
+        **And its bytecode dropped with it**, which is the same failure one
+        layer down and was missed the first time (issue #41).  A timestamp
+        ``.pyc`` is validated against the source's mtime **in whole seconds**
+        and its size, so an edit landing in the same second that leaves the
+        file the same length reloads the *previous* bytecode -- through an
+        eviction that did everything else right.  That is not the corner it
+        sounds like: ``write_extension`` replaces whole files, and a model
+        fixing one character in a format string sends back a file of identical
+        length, seconds later.  Measured, twice: once on the ``start_action``
+        path, where the fix landed, and again here through ``reload_config``,
+        where the reasoning for leaving it out ("a config reload happens by
+        hand and rarely") stopped being true the moment an agent started
+        calling it in a loop.
         """
         resolved = os.path.realpath(extensions_dir)
 
@@ -264,6 +333,53 @@ class Keymap:
             path = getattr(module, "__file__", None)
             if path and os.path.realpath(path).startswith(prefix):
                 del sys.modules[name]
+                _extension_stamps.pop(name, None)
+
+        shutil.rmtree(os.path.join(resolved, "__pycache__"), ignore_errors=True)
+
+    @staticmethod
+    def _stamp_extensions(extensions_dir: str) -> None:
+        """Record which file, at which mtime, each loaded extension came from.
+
+        Called once the configuration script has finished importing, which is
+        the only moment anything knows: a plain ``import`` leaves no trace of
+        *when* it read the file, and there is no import hook here to add one.
+
+        What it buys is that something else can ask whether the copy in
+        ``sys.modules`` is still the file on disk -- see
+        :meth:`_loaded_extension`, and issue #40 for what happened without it.
+        """
+        for name, path in _extension_files(extensions_dir):
+            _extension_stamps[name] = (path, _source_mtime(path))
+
+    @staticmethod
+    def _loaded_extension(module_name: str, path: str):
+        """The module already loaded from `path`, or None if it is not current.
+
+        The whole of the answer to issue #40.  ``start_action`` used to evict
+        and re-import unconditionally, so a class it ran and the *same* class
+        bound to a key came from two different module objects and shared no
+        module-level state at all -- two caches, two connections, two counters,
+        numbered independently.  A module that has not changed since it was
+        loaded is the one to run.
+
+        When the file *has* changed, this returns None and the caller
+        re-imports: the divergence then lasts exactly as long as it is correct,
+        because until the operator reloads, the class on their key genuinely is
+        the previous version.
+        """
+        module = sys.modules.get(module_name)
+        if module is None:
+            return None
+        stamp = _extension_stamps.get(module_name)
+        if stamp is None:
+            return None
+        stamped_path, stamped_mtime = stamp
+        if stamped_path != os.path.realpath(path):
+            return None
+        if stamped_mtime != _source_mtime(path):
+            return None
+        return module
 
     def reload_config(self) -> None:
         """Reload the configuration file.

--- a/keyhac/core/ui.py
+++ b/keyhac/core/ui.py
@@ -58,14 +58,32 @@ class UI:
     # -- finding somewhere to start ------------------------------------------
 
     def focused(self) -> UINode | None:
-        """The element with keyboard focus, as a node.
+        """The element with keyboard focus right now, as a node.
 
         The cheapest root there is: a key binding already told you which
         application and which field the user meant (design document §3.2).
+
+        **Asked each time, not remembered.** This used to hand back
+        `keymap.focus`, which is a snapshot taken while a key was being
+        dispatched - so an action that closed a window and waited for focus to
+        land somewhere else never saw it move, and kept being handed the
+        destroyed element, or the application that no longer had a window.
+        Polling did not help, because polling produces no keystrokes and only a
+        keystroke refreshed it (issue #44).
+
+        `keymap.focus` stays what it was, on purpose. Deciding which key table
+        applies to a keystroke needs the focus *that keystroke* was aimed at,
+        and re-reading it there would race the key it is dispatching. The two
+        are different questions; this is the one an action is asking.
+
+        Returns:
+            The focused element, or None when nothing has focus or the
+            platform could not say. None is an answer - a stale element that
+            fails every attribute read is not.
         """
-        focus = self._keymap.focus
-        element = getattr(focus, "element", None) if focus else None
-        return self.node(element)
+        provider = self._keymap._focus_provider
+        return self.on_main_thread(
+            lambda: self.node(provider.get_focused_element()))
 
     def window(self, app: str = None, title: str = None,
                class_name: str = None) -> UINode | None:

--- a/keyhac/mcp/extensions.py
+++ b/keyhac/mcp/extensions.py
@@ -72,55 +72,140 @@ class ActionClass:
 def discover(extensions_dir: str) -> list[ActionClass]:
     """Every action class under `extensions_dir`, found without importing.
 
-    Files whose names start with `_` are skipped: an extension named that way
-    is a helper the operator split out, not something to offer as runnable.
+    Files whose names start with `_` are skipped **as candidates**: an
+    extension named that way is a helper the operator split out, not something
+    to offer as runnable. They are still parsed, because a helper is exactly
+    where a shared base class lives and a subclass of one is an action.
     A file that does not parse is skipped rather than reported - it is being
     edited, and half a file is not a finding.
     """
+    parsed = _parse_directory(extensions_dir)
     found: list[ActionClass] = []
+    for module in sorted(parsed):
+        if module.startswith("_"):
+            continue
+        source = parsed[module]
+        for name, classdef in source.classes.items():
+            if not _is_action(parsed, module, name, set()):
+                continue
+            found.append(ActionClass(module, name, source.path,
+                                     _required_arguments(classdef),
+                                     _first_line(ast.get_docstring(classdef))))
+    return found
+
+
+class _Parsed:
+    """One file's top-level classes, and where its names came from."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.classes: dict[str, ast.ClassDef] = {}   # in file order
+        self.from_imports: dict[str, tuple[str, str]] = {}
+        self.modules: dict[str, str] = {}
+
+
+def _parse_directory(extensions_dir: str) -> dict[str, _Parsed]:
+    parsed: dict[str, _Parsed] = {}
     try:
         entries = sorted(os.listdir(extensions_dir))
     except OSError:
-        return found
+        return parsed
     for entry in entries:
-        if not entry.endswith(".py") or entry.startswith("_"):
+        if not entry.endswith(".py"):
             continue
         path = os.path.join(extensions_dir, entry)
         try:
             with open(path, encoding="utf-8") as handle:
-                source = handle.read()
-        except OSError:
+                tree = ast.parse(handle.read(), path)
+        except (OSError, SyntaxError):
             continue
-        for cls, required, summary in _action_classes(source, path):
-            found.append(ActionClass(entry[:-3], cls, path, required, summary))
-    return found
+        parsed[entry[:-3]] = _read_module(tree, path)
+    return parsed
 
 
-def _action_classes(source: str, path: str):
-    try:
-        tree = ast.parse(source, path)
-    except SyntaxError:
-        return []
-    found = []
+def _read_module(tree, path: str) -> _Parsed:
+    source = _Parsed(path)
     for node in tree.body:
-        if isinstance(node, ast.ClassDef) and any(
-                _is_threaded_action(base) for base in node.bases):
-            found.append((node.name, _required_arguments(node),
-                          _first_line(ast.get_docstring(node))))
-    return found
+        if isinstance(node, ast.ClassDef):
+            source.classes[node.name] = node
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                source.modules[alias.asname or root] = root
+        elif isinstance(node, ast.ImportFrom) and not node.level:
+            origin = (node.module or "").split(".")[0]
+            for alias in node.names:
+                source.from_imports[alias.asname or alias.name] = (origin,
+                                                                   alias.name)
+    return source
 
 
-def _is_threaded_action(base) -> bool:
-    # Both spellings the skill's import header can produce: `ThreadedAction`
-    # from `from keyhac import ...`, and a dotted one if it was reached through
-    # the package. Matching on the trailing name is deliberately loose - the
-    # cost of a false positive is one row in a list, and the cost of a false
-    # negative is an action the model cannot see.
-    if isinstance(base, ast.Name):
-        return base.id == "ThreadedAction"
-    if isinstance(base, ast.Attribute):
-        return base.attr == "ThreadedAction"
+def _is_action(parsed: dict[str, _Parsed], module: str, class_name: str,
+               seen: set) -> bool:
+    """Whether `module.class_name` reaches `ThreadedAction` through its bases.
+
+    **Transitively, and across files.** Matching only a *direct* base spelled
+    `ThreadedAction` made the natural way to reuse an action - subclass it -
+    the one way to write one this cannot see, so `start_action` could not run
+    it while a key binding ran it perfectly (issue #43). The workaround was to
+    name `ThreadedAction` a second time among the bases, which is a line of
+    code written to satisfy a scanner.
+
+    Still no import: reading a directory must not execute it, which is the
+    property this whole module is built around. So the graph is the one the
+    files describe - classes defined here, and names they imported from each
+    other - and a base that leads out of `extensions/` simply ends the walk.
+
+    `seen` breaks the cycle a file being edited can describe (`class A(B)` and
+    `class B(A)`), which is unrunnable but must not hang a listing.
+    """
+    key = (module, class_name)
+    if key in seen:
+        return False
+    seen.add(key)
+
+    source = parsed.get(module)
+    if source is None:
+        return False
+    classdef = source.classes.get(class_name)
+    if classdef is None:
+        return False
+
+    for base in classdef.bases:
+        # Both spellings the skill's import header can produce:
+        # `ThreadedAction` from `from keyhac import ...`, and a dotted one if
+        # it was reached through the package. Matching on the trailing name is
+        # deliberately loose - the cost of a false positive is one row in a
+        # list, and the cost of a false negative is an action nobody can see.
+        if _base_name(base) == "ThreadedAction":
+            return True
+        target = _base_target(source, module, base)
+        if target is not None and _is_action(parsed, *target, seen):
+            return True
     return False
+
+
+def _base_name(base) -> str | None:
+    if isinstance(base, ast.Name):
+        return base.id
+    if isinstance(base, ast.Attribute):
+        return base.attr
+    return None
+
+
+def _base_target(source: _Parsed, module: str, base) -> tuple[str, str] | None:
+    """Which `(module, class)` in `extensions/` a base expression names."""
+    # `helpers.Base` - a module imported here, addressed by attribute.
+    if isinstance(base, ast.Attribute) and isinstance(base.value, ast.Name):
+        origin = source.modules.get(base.value.id)
+        return (origin, base.attr) if origin else None
+    if not isinstance(base, ast.Name):
+        return None
+    # `Base` - defined in this file, or imported by name from another.
+    if base.id in source.classes:
+        return (module, base.id)
+    imported = source.from_imports.get(base.id)
+    return imported if imported else None
 
 
 def _required_arguments(classdef) -> list[str]:

--- a/keyhac/mcp/extensions.py
+++ b/keyhac/mcp/extensions.py
@@ -27,6 +27,14 @@ file's mtime and re-imports when it moves, so `write_extension` followed by
 - and it evicts the whole directory first, so a helper module the action
 imports is re-read too rather than answering out of `sys.modules`.
 
+**And when it has not moved, what runs is the module `config.py` imported.**
+Re-importing an unchanged file used to be unconditional, which quietly made two
+of every action: the one on the operator's key and the one started from here
+came from different module objects, so anything a module held - a cache, a
+connection, a counter - existed twice and neither copy saw the other's writes
+(issue #40). Sharing the loaded module is the ordinary case; a fresh import is
+what an edit buys.
+
 The marker is `ThreadedAction`. An action that drives a UI has to be one (a key
 press must return immediately), the authoring skill mandates it, and every
 shipped example uses it - so restricting the scan to it keeps the rule legible:
@@ -41,7 +49,6 @@ from __future__ import annotations
 import ast
 import importlib.util
 import os
-import shutil
 import sys
 
 
@@ -264,18 +271,29 @@ class Loader:
         entry = self._instances.get(action.name)
         if entry is not None and entry[0] == stamp:
             return entry[1]
-        directory = os.path.dirname(action.path)
-        # Evict the whole directory, not just this file. Re-importing the
-        # action's own module by path leaves any *helper* it imports resolving
-        # out of sys.modules - so an action split across two files would run
-        # its edited half against the previous version of the other, and report
-        # success. Measured. This is `_prepare_extensions`' own eviction, reused
-        # rather than reimplemented, since getting it subtly different is the
-        # whole hazard.
-        from keyhac.core.keymap import Keymap
-        Keymap._prepare_extensions(directory)
-        _drop_bytecode(directory)
-        module = _import_file(action.module, action.path)
+        # The module `config.py` imported, when it and everything it imports
+        # are still the files on disk. Re-importing an unchanged module is
+        # what split every action in two: the class this ran and the class on
+        # the operator's key came from different module objects, so
+        # module-level caches, connections and counters were duplicated
+        # silently (issue #40). Sharing them is the normal case - an action is
+        # edited far less often than it is run.
+        module = _loaded_and_current(action)
+
+        if module is None:
+            directory = os.path.dirname(action.path)
+            # Evict the whole directory, not just this file. Re-importing the
+            # action's own module by path leaves any *helper* it imports
+            # resolving out of sys.modules - so an action split across two
+            # files would run its edited half against the previous version of
+            # the other, and report success. Measured. This is
+            # `_prepare_extensions`' own eviction, reused rather than
+            # reimplemented, since getting it subtly different is the whole
+            # hazard; it drops the directory's bytecode too, for the same
+            # reason one layer down.
+            from keyhac.core.keymap import Keymap
+            Keymap._prepare_extensions(directory)
+            module = _import_file(action.module, action.path)
         loaded = getattr(module, action.class_name, None)
         if loaded is None:
             raise KeyError(f"{action.path} no longer defines "
@@ -293,21 +311,43 @@ class Loader:
         return instance
 
 
-def _drop_bytecode(directory: str) -> None:
-    """Remove `__pycache__` under `directory`, so a re-import reads the source.
+def _loaded_and_current(action: ActionClass):
+    """The loaded module for `action`, if nothing it rests on has been edited.
 
-    Evicting `sys.modules` is not enough on its own. A cached `.pyc` is
-    validated against the source's mtime **in whole seconds** and its size, so
-    two edits inside one second that happen to leave the file the same length -
-    a model fixing one character, twice - reload the *previous* bytecode and
-    report success. Measured; it is the same silent staleness the eviction
-    exists to prevent, one layer further down.
+    The freshness question covers the *import graph*, not one file. An action
+    split across two files sees its helper through `sys.modules`, so reusing a
+    module whose helper has moved would run the edited half against the
+    previous version of the other and report success - the failure the
+    directory-wide eviction exists to prevent, walked back in through the
+    door this opened.
 
-    Only on this path, not in `_prepare_extensions`: a config reload happens by
-    hand and rarely, while this one runs in a loop that edits every few seconds.
-    Bytecode is regenerable by definition, and these files are small.
+    Scoped to what this action actually imports rather than to the whole
+    directory, which is the difference between sharing modules and not: in a
+    fix loop *some* file is nearly always newer than the last configuration
+    load, and letting an unrelated one force a re-import would put the split
+    of issue #40 back for every action but the one being edited.
     """
-    shutil.rmtree(os.path.join(directory, "__pycache__"), ignore_errors=True)
+    from keyhac.core.keymap import Keymap
+
+    parsed = _parse_directory(os.path.dirname(action.path))
+    if action.module not in parsed:
+        return None
+    for name in _imported_modules(parsed, action.module, set()):
+        if Keymap._loaded_extension(name, parsed[name].path) is None:
+            return None
+    return sys.modules.get(action.module)
+
+
+def _imported_modules(parsed: dict, module: str, seen: set) -> set:
+    """`module` and every module in `extensions/` it imports, transitively."""
+    if module in seen or module not in parsed:
+        return seen
+    seen.add(module)
+    source = parsed[module]
+    for origin in (*source.modules.values(),
+                   *(origin for origin, _name in source.from_imports.values())):
+        _imported_modules(parsed, origin, seen)
+    return seen
 
 
 def _mtime(path: str) -> float:
@@ -328,8 +368,12 @@ def _import_file(module_name: str, path: str):
 
     It is still registered in `sys.modules` under its plain name, so a later
     `import thing` from `config.py` reaches the same object and
-    `_prepare_extensions` evicts it on the next reload like any other.
+    `_prepare_extensions` evicts it on the next reload like any other. And it
+    is stamped on the way out, so the *next* start recognizes it as current and
+    reuses it rather than making a second copy (issue #40).
     """
+    from keyhac.core.keymap import stamp_extension_module
+
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot load {path}")
@@ -340,4 +384,5 @@ def _import_file(module_name: str, path: str):
     except BaseException:
         sys.modules.pop(module_name, None)
         raise
+    stamp_extension_module(module_name, path)
     return module

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -88,6 +88,25 @@ def _listdir(directory: str) -> list[str]:
         return []
 
 
+def _running_action(name: str):
+    """A running action filed under `name`, whoever started it.
+
+    `ThreadedAction._running` is the set Esc reaches, so it holds key-started
+    actions the loader has never seen. Matched on the same name the run record
+    was filed under, which is what makes the two ways of starting an action
+    answer to one name at all.
+    """
+    from keyhac.core.action import ThreadedAction
+
+    with ThreadedAction._running_lock:
+        running = tuple(ThreadedAction._running)
+    for action in running:
+        if getattr(action, "_run_record", None) is not None \
+                and action._run_record.name == name:
+            return action
+    return None
+
+
 class Tool:
     """One callable, its JSON Schema, and the description Claude reads."""
 
@@ -482,8 +501,17 @@ class ToolRegistry:
         Deliberately ungated and import-free: a run that started while the
         window was open must stay readable after it closes, or the model loses
         the traceback for the thing it just ran.
+
+        Two places to look, because there are two ways to start one. The
+        loader's cache holds what `start_action` made; a run the operator
+        triggered with a key was made by their `config.py` and is reachable
+        only while it is running, through the set the Esc key uses. Without the
+        second, `cancel_action` could not stop an action the operator started -
+        which is the half of issue #42 that survived naming the runs alike.
         """
         action = self._loader.cached(name)
+        if action is None:
+            action = _running_action(name)
         if action is None:
             raise KeyError(f"{name!r} has not been started; call list_actions")
         return action

--- a/keyhac/platform/base.py
+++ b/keyhac/platform/base.py
@@ -164,6 +164,24 @@ class FocusProvider(ABC):
     @abstractmethod
     def get_focus(self) -> Focus | None: ...
 
+    def get_focused_element(self):
+        """The element with keyboard focus *now*, or None.
+
+        Separate from ``get_focus()`` because the two are asked for different
+        reasons and only one of them is a snapshot.  ``get_focus()`` runs
+        inside the keyboard hook and its answer is deliberately frozen with the
+        key being dispatched -- the whole point is to decide which key table
+        applies to *that* keystroke.  This one is asked by an action, minutes
+        later, when what it needs is the truth right now (issue #44).
+
+        The default builds the whole Focus and takes its element, which is
+        correct everywhere.  A platform overrides it to skip the part it does
+        not need: constructing the focus *path* costs a parent walk of AX or
+        UIA round trips, and nothing here reads the path.
+        """
+        focus = self.get_focus()
+        return getattr(focus, "element", None) if focus else None
+
 
 class EventLoop(ABC):
     """The main-thread native event loop (CFRunLoop / GetMessage pump)."""

--- a/keyhac/platform/mac/focus.py
+++ b/keyhac/platform/mac/focus.py
@@ -34,6 +34,31 @@ class MacFocusProvider(FocusProvider):
         self._system_wide = AS.AXUIElementCreateSystemWide()
         AS.AXUIElementSetMessagingTimeout(self._system_wide, AX_MESSAGING_TIMEOUT)
 
+    def get_focused_element(self) -> "UIElement | None":
+        """Ask the system where focus is, without building a focus path.
+
+        The same AX chain get_focus() walks, stopping at the element. Skipping
+        `_build_path` is worth a method of its own here: that walk is up to 64
+        levels of AXParent with two attribute reads each, all of it cross-
+        process, and an action polling for focus to settle pays it on every
+        turn while reading none of it.
+
+        No `AXFocusedWindow` fallback and no app element, unlike get_focus():
+        those exist so a key table can still match on *something* when the
+        focused control cannot be read, and handing an action the application
+        element as if it were the focus is how issue #44 read on screen. Here,
+        not knowing is an answer worth giving.
+        """
+        focused_app = _ax_get(self._system_wide, "AXFocusedApplication")
+        if focused_app is None:
+            app = NSWorkspace.sharedWorkspace().frontmostApplication()
+            if app is None:
+                return None
+            focused_app = AS.AXUIElementCreateApplication(
+                int(app.processIdentifier()))
+        element = _ax_get(focused_app, "AXFocusedUIElement")
+        return UIElement(element) if element is not None else None
+
     def get_focus(self) -> Focus | None:
 
         app = NSWorkspace.sharedWorkspace().frontmostApplication()

--- a/keyhac/platform/win/focus.py
+++ b/keyhac/platform/win/focus.py
@@ -135,6 +135,23 @@ class WinFocusProvider(FocusProvider):
         self._probe = None      # last cheap Win32 probe
         self._focus = None      # the Focus built for it
 
+    def get_focused_element(self):
+        """UIA's own answer, asked fresh - no probe cache, no path walk.
+
+        get_focus() answers out of `self._focus` while the foreground window,
+        the focused child and the title are unchanged, which is right for key
+        dispatch and wrong for an action: focus moves *within* a window all the
+        time, and the probe cannot see it (issue #44). This is the ~33 ms walk's
+        first level and nothing else.
+        """
+        from keyhac.platform.win.uielement import UIElement
+
+        try:
+            return UIElement.from_focus()
+        except Exception:
+            logger.debug("UIA focus query failed.", exc_info=True)
+            return None
+
     def get_focus(self) -> Focus | None:
 
         foreground = user32.GetForegroundWindow()

--- a/keyhac/skills/keyhac-action-authoring/SKILL.md
+++ b/keyhac/skills/keyhac-action-authoring/SKILL.md
@@ -180,7 +180,11 @@ Two consequences worth writing for:
   `list_actions` says so instead of offering it. Defaults keep it testable and
   lose you nothing; the operator can still pass other values on the line that
   binds the key.
-- **The class must subclass `ThreadedAction`** to be found at all.
+- **The class must subclass `ThreadedAction`** to be found at all. Any
+  distance does: subclassing another action, or a shared base you split into a
+  `_helpers.py` beside it, is found the same way. Never name `ThreadedAction` a
+  second time among the bases to make a class appear - that was a workaround
+  for a scanner that only read direct bases, and the scanner was fixed.
 
 ## Running it
 

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -1,0 +1,97 @@
+"""The `config.py` shipped to every new installation, loaded as a config.
+
+`keyhac/_config.py` is copied to `~/.keyhac/config.py` on first run and is the
+only Keyhac most people will ever read.  Nothing exercised it, so a sample that
+had stopped being true stayed shipped -- and a sample is read as a
+recommendation, not as an illustration.
+"""
+
+import pytest
+
+from keyhac.core.clipboard_history import ClipboardHistory
+from keyhac.core.keymap import Keymap
+from keyhac.platform.base import Focus
+from keyhac.platform.fake import FakeInputHook, FakeFocusProvider
+
+
+class FakeElement:
+    """Just enough to answer the one question a focus condition asks."""
+
+    def __init__(self, **attributes):
+        self.attributes = attributes
+
+    def get_attribute_value(self, name):
+        return self.attributes.get(name)
+
+
+class FakeClipboardProvider:
+    def get_text(self):
+        return ""
+
+    def set_text(self, text):
+        pass
+
+
+@pytest.fixture(params=["mac", "windows"])
+def shipped(request, tmp_path, caplog):
+    """A Keymap that loaded the real template, on each platform in turn.
+
+    Wired the way `main()` wires one, minus the OS: the template configures
+    clipboard history, so a Keymap without it fails the load and every
+    assertion below would pass against a config that never ran.
+    """
+    # No template_path: the default is `keyhac/_config.py`, which is the file
+    # under test - naming it here would let the two drift apart.
+    keymap = Keymap(FakeInputHook("ansi"), FakeFocusProvider(), request.param,
+                    config_path=str(tmp_path / "config.py"))
+    keymap._clipboard_history = ClipboardHistory(
+        FakeClipboardProvider(), str(tmp_path / "clipboard.json"))
+
+    with caplog.at_level("ERROR"):
+        keymap.configure()
+
+    # configure() reports a broken config to the console and returns, so this
+    # is the difference between "the sample loads" and "the sample half-loaded
+    # and the tests below found nothing to disagree with".
+    assert not caplog.records, caplog.text
+    return keymap
+
+
+def custom_conditions(keymap):
+    return [condition for condition, _table in keymap._keytable_list
+            if condition.custom_condition_func is not None]
+
+
+def focus_on(element, app_name="SomeEditor"):
+    return Focus(app_name=app_name, pid=1, window_title="Main",
+                 path="/App/Window", element=element, native=element)
+
+
+def test_the_template_loads_on_both_platforms(shipped):
+    """It is executed for the first time on somebody's first run."""
+    assert shipped._keytable_list, "the sample defined no key tables"
+
+
+def test_a_text_area_is_not_a_terminal(shipped):
+    """Issue #46, and it shipped inverted.
+
+    The sample's `is_terminal` fell back to `role in ("AXTextArea",
+    "Document")` when the application name did not match. `AXTextArea` means
+    "multi-line text control", not "terminal": it caught the VS Code editor and
+    every chat box on the machine, and *missed* VS Code's own integrated
+    terminal, which is an AXTextField. Since the sample rebinds `LEADER-K`
+    inside that table, a fresh install turned `Fn-K` into `Ctrl-K` everywhere
+    text is typed and left it alone in an actual terminal.
+    """
+    editor = focus_on(FakeElement(AXRole="AXTextArea", ControlType="Document"))
+    for condition in custom_conditions(shipped):
+        assert not condition.check(editor), \
+            "a text area still satisfies a sample condition"
+
+
+def test_a_named_terminal_still_matches(shipped):
+    """Removing the wrong half must not remove the working half."""
+    terminal = focus_on(FakeElement(), app_name="Terminal")
+    assert any(condition.check(terminal)
+               for condition in custom_conditions(shipped)), \
+        "no sample condition recognises Terminal any more"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -85,6 +85,88 @@ def test_a_reload_picks_up_an_edit(extensions):
     assert edited_action.VALUE == "after", "the edit was not picked up"
 
 
+def test_a_reload_picks_up_an_edit_a_pyc_would_hide(extensions):
+    """Issue #41: the same silent staleness, one layer below sys.modules.
+
+    A timestamp .pyc is validated on int(mtime) and size, so an edit inside one
+    whole second that leaves the file the same length reloads the *previous*
+    bytecode through an eviction that did everything else right. Not the corner
+    it sounds like - write_extension replaces whole files, and a one-character
+    fix to a format string is a file of identical length seconds later.
+
+    The mtimes here are pinned rather than raced: the point is the arithmetic
+    the import system does, not whether this machine is fast enough to lose.
+    """
+    write(extensions, "same_length", "VALUE = 'aaa'")
+    path = extensions / "same_length.py"
+    os.utime(path, (1_000_000_000.25, 1_000_000_000.25))
+
+    Keymap._prepare_extensions(str(extensions))
+    import same_length
+    assert same_length.VALUE == "aaa"
+    assert (extensions / "__pycache__").exists(), \
+        "no .pyc was written, so this test is not testing anything"
+
+    write(extensions, "same_length", "VALUE = 'bbb'")     # same byte length
+    os.utime(path, (1_000_000_000.75, 1_000_000_000.75))  # same whole second
+
+    Keymap._prepare_extensions(str(extensions))           # what a reload does
+
+    import same_length
+    assert same_length.VALUE == "bbb", "the edit was hidden by stale bytecode"
+
+
+def test_a_loaded_module_is_recognized_as_current(extensions):
+    """Issue #40's other half: knowing when *not* to re-import.
+
+    Nothing else can answer this. A plain `import` leaves no record of when it
+    read the file, so without the stamp taken after a config load, every reader
+    has to assume the worst and load its own copy - which is exactly what made
+    two of every action.
+    """
+    write(extensions, "shared_state", "VALUE = 'loaded'")
+    path = str(extensions / "shared_state.py")
+
+    Keymap._prepare_extensions(str(extensions))
+    import shared_state
+    Keymap._stamp_extensions(str(extensions))             # end of configure()
+
+    assert Keymap._loaded_extension("shared_state", path) is shared_state
+
+    write(extensions, "shared_state", "VALUE = 'edited'")
+    assert Keymap._loaded_extension("shared_state", path) is None, \
+        "an edited file must not be answered out of sys.modules"
+
+
+def test_an_unstamped_module_is_not_claimed_as_current(extensions):
+    """A module nobody vouched for is not one to reuse."""
+    write(extensions, "unstamped", "VALUE = 1")
+    Keymap._prepare_extensions(str(extensions))
+    import unstamped                                       # noqa: F401
+
+    assert Keymap._loaded_extension(
+        "unstamped", str(extensions / "unstamped.py")) is None
+
+
+def test_a_reload_forgets_what_it_evicted(extensions):
+    """The stamp must not outlive the module it describes.
+
+    Otherwise a reload leaves a stamp pointing at an unchanged file with no
+    module behind it, and the next lookup would claim whatever `sys.modules`
+    happened to hold under that name.
+    """
+    write(extensions, "evicted", "VALUE = 1")
+    path = str(extensions / "evicted.py")
+    Keymap._prepare_extensions(str(extensions))
+    import evicted                                         # noqa: F401
+    Keymap._stamp_extensions(str(extensions))
+
+    Keymap._prepare_extensions(str(extensions))
+    sys.modules["evicted"] = object()                      # someone else's
+
+    assert Keymap._loaded_extension("evicted", path) is None
+
+
 def test_a_reload_leaves_unrelated_modules_alone(extensions):
     """Only modules loaded *from* the directory are dropped."""
     Keymap._prepare_extensions(str(extensions))

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import stat
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -22,6 +23,7 @@ import urllib.request
 import pytest
 
 import keyhac.core.keymap as keymap_module
+from keyhac.core import capture
 import keyhac.mcp.server as server_module
 import keyhac.mcp.tools as tools_module
 from keyhac.mcp.server import Dispatcher, MCPServer, PROTOCOL_VERSION
@@ -747,6 +749,88 @@ def test_an_edit_still_wins_over_the_loaded_module(writable, clean_modules):
     os.utime(path, (0, 0))
 
     assert writable._startable("moved.Thing").run() == 2
+
+
+# -- both ways of starting one answer to one name (issue #42) ----------------
+#
+# get_action_result returned only what start_action had run. Press the key the
+# action is bound to and it handed back the *previous* MCP run, unchanged -
+# same text, same counter - while list_actions said "not run yet" about an
+# action the operator had just run. The two paths filed their records under
+# different keys: repr(self) for a key press, module.Class for the tool. It
+# cost one wrong conclusion ("the key press is not reaching the hook") about a
+# hook that was working.
+
+def _run_as_a_key_press(action):
+    """What ThreadedAction._run_tracked does: cancellable() with no name.
+
+    The cancellation is swallowed the way the pool swallows it - it lands in
+    the future, and _finish logs it - rather than being left to surface out of
+    a bare thread.
+    """
+    from keyhac.core.action import ActionCancelled
+
+    try:
+        with action.cancellable():
+            return action.run()
+    except ActionCancelled:
+        return None
+
+
+def test_a_key_press_run_is_readable_by_name(engine, tmp_path, clean_modules):
+    keymap = engine(lambda keymap: None).keymap
+    directory = keymap.extensions_dir
+    os.makedirs(directory, exist_ok=True)
+    pathlib.Path(directory, "pressed.py").write_text(RUNNABLE.format(version=7))
+
+    keymap_module.Keymap._prepare_extensions(directory)
+    import pressed
+    _run_as_a_key_press(pressed.Thing())          # the operator's own binding
+
+    registry = ToolRegistry(keymap)
+    result = registry.call("get_action_result",
+                           {"name": "pressed.Thing", "wait": 0})
+    assert "finished" in result, result
+    assert "has not been run" not in result
+    assert "last run: finished" in registry.call("list_actions", {})
+
+
+def test_a_key_press_run_is_cancellable_by_name(engine, tmp_path, clean_modules):
+    """The other half: cancel_action reaches instances it did not create."""
+    keymap = engine(lambda keymap: None).keymap
+    directory = keymap.extensions_dir
+    os.makedirs(directory, exist_ok=True)
+    pathlib.Path(directory, "held.py").write_text(SLOW.replace("Slow", "Held"))
+
+    keymap_module.Keymap._prepare_extensions(directory)
+    import held
+    action = held.Held()
+    thread = threading.Thread(target=_run_as_a_key_press, args=(action,),
+                              daemon=True)
+    thread.start()
+
+    registry = ToolRegistry(keymap)
+    deadline = time.monotonic() + 5
+    while capture.get_run("held.Held") is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    registry.call("cancel_action", {"name": "held.Held"})
+    thread.join(timeout=5)
+    assert "cancelled" in registry.call("get_action_result",
+                                        {"name": "held.Held", "wait": 5})
+
+
+def test_an_action_outside_extensions_keeps_its_repr(engine):
+    """`LaunchApplication("Terminal.app")` says which application.
+
+    `keyhac.core.action.LaunchApplication` says neither that nor which of two
+    bindings ran, so the class-derived name is for `extensions/` only.
+    """
+    engine(lambda keymap: None)
+    from keyhac.core.action import LaunchApplication
+
+    action = LaunchApplication("Terminal.app")
+    assert action._run_name() == 'LaunchApplication("Terminal.app")'
 
 
 SLOW = '''\

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -632,6 +632,123 @@ def test_an_unchanged_file_keeps_its_instance(writable):
     assert writable._startable("thing.Thing") is writable._startable("thing.Thing")
 
 
+# -- one module, not two (issue #40) -----------------------------------------
+
+STATEFUL = '''\
+import itertools
+
+from keyhac import ThreadedAction
+
+RUNS = itertools.count(1)
+
+
+class Counted(ThreadedAction):
+    def run(self):
+        return next(RUNS)
+'''
+
+
+@pytest.fixture
+def clean_modules():
+    before = set(sys.modules)
+    yield
+    for name in set(sys.modules) - before:
+        del sys.modules[name]
+
+
+def test_it_runs_the_module_the_config_imported(writable, clean_modules):
+    """Issue #40: start_action used to re-import, unconditionally.
+
+    So a class on the operator's key and the same class started from here came
+    from two different module objects. Anything the module held existed twice
+    and neither copy saw the other's writes - which showed up as a run counter
+    going 3, then 2, with the 2 twenty-five seconds later.
+    """
+    write_action(writable, name="counted", source=STATEFUL)
+    directory = str(extensions(writable))
+
+    keymap_module.Keymap._prepare_extensions(directory)
+    import counted                                    # what config.py does
+    keymap_module.Keymap._stamp_extensions(directory)  # end of configure()
+
+    started = writable._startable("counted.Counted")
+
+    assert type(started) is counted.Counted, "a second copy of the class"
+    assert sys.modules["counted"] is counted
+
+    # The counter is the visible half: two modules would restart it.
+    assert counted.Counted().run() == 1
+    assert started.run() == 2
+
+
+def test_an_edited_helper_wins_over_the_loaded_module(writable, clean_modules):
+    """Sharing must not become the staleness it replaced.
+
+    An action reaches its helper through sys.modules, so reusing a module
+    whose *helper* moved would run the edited half against the previous
+    version of the other and report success - the failure the directory-wide
+    eviction exists to prevent, walked back in through the door #40's fix
+    opened.
+    """
+    directory = extensions(writable)
+    write_action(writable, name="_lib", source="VALUE = 1\n")
+    write_action(writable, name="uses_lib", source=(
+        "from keyhac import ThreadedAction\n"
+        "import _lib\n\n\n"
+        "class Uses(ThreadedAction):\n"
+        "    def run(self):\n"
+        "        return _lib.VALUE\n"))
+
+    keymap_module.Keymap._prepare_extensions(str(directory))
+    import uses_lib                                    # noqa: F401
+    keymap_module.Keymap._stamp_extensions(str(directory))
+
+    (directory / "_lib.py").write_text("VALUE = 2\n")   # only the helper moved
+
+    assert writable._startable("uses_lib.Uses").run() == 2
+
+
+def test_an_unrelated_edit_does_not_split_the_module(writable, clean_modules):
+    """The reason freshness follows the import graph and not the directory.
+
+    In a fix loop some file is nearly always newer than the last configuration
+    load. If any of them forced a re-import, every action but the one being
+    edited would go back to running its own private copy - which is issue #40
+    with extra steps.
+    """
+    directory = extensions(writable)
+    write_action(writable, name="quiet", source=STATEFUL)
+    write_action(writable, name="noisy", source=RUNNABLE.format(version=1))
+
+    keymap_module.Keymap._prepare_extensions(str(directory))
+    import quiet
+    keymap_module.Keymap._stamp_extensions(str(directory))
+
+    (directory / "noisy.py").write_text(RUNNABLE.format(version=2))
+
+    assert type(writable._startable("quiet.Counted")) is quiet.Counted
+
+
+def test_an_edit_still_wins_over_the_loaded_module(writable, clean_modules):
+    """Sharing must not become staleness.
+
+    Until the operator reloads, the class on their key genuinely *is* the
+    previous version - so the moment the file moves, this has to go back to
+    importing its own.
+    """
+    path = write_action(writable, name="moved", source=RUNNABLE.format(version=1))
+    directory = str(extensions(writable))
+
+    keymap_module.Keymap._prepare_extensions(directory)
+    import moved                                       # noqa: F401
+    keymap_module.Keymap._stamp_extensions(directory)
+
+    path.write_text(RUNNABLE.format(version=2))
+    os.utime(path, (0, 0))
+
+    assert writable._startable("moved.Thing").run() == 2
+
+
 SLOW = '''\
 import time
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -469,6 +469,104 @@ def test_underscore_files_are_helpers_not_actions(writable):
     assert "OpenIssues" not in writable.call("list_actions", {})
 
 
+# -- inheritance, without importing (issue #43) ------------------------------
+#
+# Reusing an action by subclassing it is the natural thing to write, and it was
+# the one way to write one this could not see: matching a *direct* base spelled
+# ThreadedAction meant `class B(A)` vanished while `class B(A, ThreadedAction)`
+# - identical MRO, the base named twice - appeared. The workaround was a line
+# of code written to satisfy a scanner.
+
+INHERITED = '''\
+from keyhac import ThreadedAction
+
+
+class TranslateClipboard(ThreadedAction):
+    """Translate the clipboard."""
+
+    def run(self):
+        return "clipboard"
+
+
+class TranslateSelection(TranslateClipboard):
+    """Translate the selection."""
+
+    def run(self):
+        return "selection"
+'''
+
+
+def test_a_subclass_of_an_action_is_an_action(writable):
+    write_action(writable, source=INHERITED)
+    result = writable.call("list_actions", {})
+    assert "thing.TranslateSelection: Translate the selection." in result
+
+
+def test_it_follows_a_base_class_into_another_module(writable):
+    """An action's base often lives in the helper file beside it."""
+    write_action(writable, name="_base", source=(
+        "from keyhac import ThreadedAction\n\n\n"
+        "class Base(ThreadedAction):\n"
+        "    def run(self): ...\n"))
+    write_action(writable, name="derived", source=(
+        "from _base import Base\n\n\n"
+        "class Derived(Base):\n"
+        '    """Built on the helper."""\n'
+        "    def run(self): ...\n"))
+
+    result = writable.call("list_actions", {})
+    assert "derived.Derived: Built on the helper." in result
+    assert "_base.Base" not in result, "a helper file is still not offered"
+
+
+def test_it_follows_a_base_reached_through_a_module(writable):
+    write_action(writable, name="_base", source=(
+        "from keyhac import ThreadedAction\n\n\n"
+        "class Base(ThreadedAction):\n"
+        "    def run(self): ...\n"))
+    write_action(writable, name="dotted", source=(
+        "import _base\n\n\n"
+        "class Dotted(_base.Base):\n"
+        '    """Reached through the module."""\n'
+        "    def run(self): ...\n"))
+
+    assert "dotted.Dotted: Reached through the module." in \
+        writable.call("list_actions", {})
+
+
+def test_a_class_inheriting_something_else_is_still_not_an_action(writable):
+    """The walk must widen what is found, not stop discriminating."""
+    write_action(writable, source=(
+        "class Helper:\n    pass\n\n\n"
+        "class Plain(Helper):\n    pass\n"))
+    assert "Plain" not in writable.call("list_actions", {})
+
+
+def test_a_base_cycle_does_not_hang_the_listing(writable):
+    """Half a file is not a finding, and a file being edited can say this.
+
+    Reaching the assertion at all is most of the test: an unguarded walk
+    recurses until the interpreter stops it.
+    """
+    write_action(writable, source=(
+        "class A(B):\n    pass\n\n\n"
+        "class B(A):\n    pass\n"))
+    result = writable.call("list_actions", {})
+    assert "thing.A" not in result and "thing.B" not in result
+
+
+def test_inheritance_is_resolved_without_importing(writable):
+    """The property the whole AST scan exists for still holds."""
+    write_action(writable, name="explodes", source=(
+        "from keyhac import ThreadedAction\n"
+        "raise AssertionError('imported')\n\n\n"
+        "class Base(ThreadedAction):\n    pass\n\n\n"
+        "class Derived(Base):\n    pass\n"))
+
+    assert "explodes.Derived" in writable.call("list_actions", {})
+    assert "explodes" not in sys.modules
+
+
 # -- loading one -------------------------------------------------------------
 
 RUNNABLE = '''\

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -159,6 +159,64 @@ def test_windows_returns_all_matches(ui):
     assert api.windows(app="Nope") == []
 
 
+# -- focused() asks, it does not remember (issue #44) ------------------------
+#
+# This used to read `keymap.focus`, which is a snapshot taken while a key was
+# being dispatched. An action that closed a window and waited for focus to
+# land somewhere else never saw it move: it kept being handed the destroyed
+# element, or the application that no longer had a window, and polling did not
+# help because polling produces no keystrokes.
+
+def test_focused_asks_the_platform_each_time(ui):
+    api, _element = ui
+    provider = api._keymap._focus_provider
+
+    first, second = FakeElement("AXTextArea", name="Editor", key="e"), \
+        FakeElement("AXTextField", name="Search", key="s")
+    provider.get_focused_element = lambda: provider.element
+
+    provider.element = first
+    assert api.focused().name == "Editor"
+
+    provider.element = second                  # focus moved; no key was typed
+    assert api.focused().name == "Search", \
+        "focused() answered from a snapshot instead of asking"
+
+
+def test_focused_does_not_read_the_keypress_snapshot(ui):
+    """A stale element that fails every attribute read is not an answer.
+
+    None is: the caller can branch on it, and an action waiting for focus to
+    settle keeps waiting instead of driving a window that is gone. So the
+    snapshot is loaded here with exactly what the report saw - the destroyed
+    window still sitting in `keymap.focus` - and focused() must not reach it.
+    """
+    api, _element = ui
+    keymap = api._keymap
+    keymap._focus = keymap._focus_provider.get_focus()
+    keymap._focus.element = FakeElement("AXWindow", name="Destroyed", key="x")
+    keymap._focus_provider.get_focused_element = lambda: None
+
+    assert api.focused() is None
+
+
+def test_the_default_provider_reads_the_live_focus(engine):
+    """Every provider gets this for free; only the cost differs.
+
+    macOS and Windows override it to skip building the focus *path* - a parent
+    walk of cross-process round trips that nothing here reads.
+    """
+    from keyhac.platform.base import Focus, FocusProvider
+
+    element = FakeElement("AXTextArea", name="Body", key="b")
+
+    class Minimal(FocusProvider):
+        def get_focus(self):
+            return Focus(app_name="App", pid=1, element=element)
+
+    assert Minimal().get_focused_element() is element
+
+
 def test_node_wraps_a_platform_element_shallowly(ui):
     api, element = ui
     node = api.node(element)


### PR DESCRIPTION
Six issues found while writing a `TranslateSelection` action from Claude
Desktop, all reproduced against the tree before being fixed. One commit each,
except the two that are genuinely one change.

| | |
|---|---|
| #40 | `extensions/` modules loaded twice — `start_action` and `config.py` saw different module objects |
| #41 | `reload_config` ran the previous version of an edited module (stale `.pyc`) |
| #42 | `get_action_result` never saw a run started by a key press |
| #43 | `list_actions` missed an action class that subclassed another action class |
| #44 | `ui.focused()` returned a snapshot from the last keypress, not the current focus |
| #46 | The shipped `config.py` sample matched every `AXTextArea` as a terminal |

#45 (`get_active_window()` / `AXFrontmost` reporting the wrong frontmost app)
is **left open on purpose.** Its evidence is confounded by #44: the comparison
that produced it read `ui.focused()` as ground truth, but that was the snapshot
and `get_active_window()` was the live query, so it cannot say which one was
wrong. It wants re-measuring now that `focused()` is live — and any change
there moves what `define_keytable(app=...)` matches on, for every existing
configuration.

## Notes on the fixes

**#40** is the one with a design decision in it. Freshness follows the
**import graph**, not one file and not the whole directory. Per-file would let
a stale helper through — an action reaches its helper via `sys.modules`, so
reusing a module whose helper moved runs the edited half against the previous
version of the other and reports success. Per-directory would be simpler and
useless: in a fix loop some file is nearly always newer than the last config
load, so every action but the one being edited would go back to its own copy.

**#41** was already fixed once, on the `start_action` path, with a note
explaining why `_prepare_extensions` did not need it: "a config reload happens
by hand and rarely." That stopped being true when an agent started calling
`reload_config` in a loop.

**#44** changes `ui.focused()` and leaves `keymap.focus` alone. Key table
selection needs the focus *that keystroke* was aimed at; re-reading it there
would race the key being dispatched. Two different questions, one of which had
never been answered.

**#46** ships with the first test `keyhac/_config.py` has ever had. It is the
only Keyhac most people read, and nothing exercised it, which is how a sample
that had stopped being true stayed shipped.

## Verification

477 tests pass, up from 451. Every new test was run against the unfixed code
first and fails without its fix — including the two `.pyc` and module-identity
cases, which use mtimes written by hand rather than raced, since the point is
the arithmetic the import system does and not whether the machine is fast
enough to lose.

`extensions.py` and `test_mcp.py` each carry work belonging to more than one
commit, so the split was done by reconstructing intermediate file contents
rather than staging hunks. Each of the six commits was then checked out into a
worktree and tested on its own: 457 → 465 → 468 → 471 → 477 → 477 passing,
nothing red in between.

`make api-reference-check` is green again. It had been failing since c050b42 —
`doc/config-api.md` still documented `action_authoring_allowed` /
`action_authoring_lapsed`, removed there — so the last commit is purely that
regeneration, kept separate so neither has to be read through the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
