### PR TITLE
Say which Keyhac this is, before anything can stop it

### DIFF
--- a/keyhac/main.py
+++ b/keyhac/main.py
@@ -13,10 +13,13 @@ import argparse
 import signal
 import sys
 
+from keyhac import __version__
 from keyhac.core import log, paths
 from keyhac.core.keymap import Keymap
 
 logger = log.getLogger("Main")
+
+WEBSITE_URL = "https://crftwr.github.io/keyhac/"
 
 
 def main() -> int:
@@ -32,6 +35,18 @@ def main() -> int:
     args = parser.parse_args()
 
     log.set_debug(args.debug)
+
+    # First line of every run, before anything that can fail: which build this
+    # is, and where its documentation is. The console window backfills the
+    # lines logged before it opened, so it heads that too - and a run that
+    # stops at the single-instance check or the accessibility prompt has still
+    # said which version stopped.
+    #
+    # A banner, not a record: no level and no source name in front of it. That
+    # is what print() writes here, except that print() only becomes console
+    # output at redirect_std_streams() below, which is after the point where
+    # this has to be said - so it goes to the same place by hand.
+    log.Console.get_instance().write(f"Keyhac {__version__} - {WEBSITE_URL}\n")
 
     if sys.platform == "darwin":
         platform_name = "mac"


### PR DESCRIPTION
Every run now opens with

```
Keyhac 2.2.1 - https://crftwr.github.io/keyhac/
```

the line a bug report should start with, and the one that answers "which version am I running" without opening a menu. `doc/ai-integration.md` already told an agent to read the version from what the console prints at startup; until now it printed `Keyhac 2 running (mac, config: ...)`, with no version in it.

It lands before the single-instance check and the accessibility prompt, so a launch that stops there has still named the build that stopped, and the console window backfills lines logged before it opened, so it heads that too.

Written through `log.Console` rather than `logger.info` because it is a banner and not a record — `INFO [keyhac.Main] ` in front of the product name reads as diagnostics. That is what `print()` writes here, except `print()` only becomes console output at `redirect_std_streams()`, which is after the point where this has to be said.

477 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)