### PR TITLE
A session could read every window on the screen and leave no trace

### DIFF
--- a/doc/ai-integration.md
+++ b/doc/ai-integration.md
@@ -74,7 +74,25 @@ open and can run the actions you register. See [Security](#security).
 
 Tick **AI Integration: MCP Server** in the console window, or
 **AI Integration → MCP Server** in the tray / menu bar menu. The console logs
-the port it chose.
+the port it chose, and then one line for every call the agent makes — which
+tool, with which arguments, and how big an answer went back:
+
+```
+INFO [keyhac.MCP] describe_screen(app='Chrome') -> 4812 chars
+INFO [keyhac.MCP] write_extension(name='translate_clipboard', source='import ...') -> 118 chars
+```
+
+Set the console's level to **Debug** for the whole of each request and reply
+rather than a summary. The envelope stays on one line and the payload is
+printed underneath as itself, so a screen dump reads as the tree it is:
+
+```
+DEBUG [keyhac.MCP] <- {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"<result.content[0].text>"}],"isError":false}}
+AXWindow 'my-projects (Workspace)'
+  AXGroup 'my-projects (Workspace)'
+    AXWebArea 'my-projects (Workspace)'
+      AXStaticText = 'Diff editor'
+```
 
 **It turns itself off after 60 minutes**, and it is not remembered across
 restarts. Tick it again when you need it — that is the intended rhythm, not an
@@ -481,6 +499,10 @@ don't type passwords or show private material while recording.
   another process on the machine cannot use the endpoint without it.
 - **It closes itself after 60 minutes**, and is never restored at startup, so
   the exposure lasts as long as the work rather than as long as you forget.
+- **Every call is on the console**, one line each, whether or not it changed
+  anything: reading a window leaves a trace the same way writing a file does.
+  The chat window shows you what the agent chose to tell you about; this shows
+  you what it actually asked Keyhac for.
 - **Two places can be written, and no others**: a `.py` under
   `~/.keyhac/extensions/` — the name has to be an importable module name, which
   is what rules out paths and traversal — and `config.py` itself. Neither is
@@ -527,5 +549,5 @@ what it says it does.
 
 The practical answer is therefore built in rather than left to you: the exposure
 coincides with you sitting in front of the screen, watching a console that
-reports every write, and it ends by itself. Which is worth more than a gate
-nobody reads.
+reports every call and not only every write, and it ends by itself. Which is
+worth more than a gate nobody reads.

--- a/keyhac/core/capture.py
+++ b/keyhac/core/capture.py
@@ -42,6 +42,14 @@ MAX_CAPTURE = 20_000
 #: not losing the halves that say how the run ended.
 _captures: list = []
 
+#: The MCP server's own logger, which is the one thing on the `keyhac` tree
+#: that is never an action's output: it reports the calls made *about* the
+#: action, one line each. A run lasts minutes and a model polls it, so without
+#: this every `get_action_result` comes back quoting the calls that read it.
+#: Named rather than imported - `keyhac.mcp` imports this module, not the
+#: reverse - and matched exactly, since it is produced in exactly one place.
+_MCP_LOGGER = "keyhac.MCP"
+
 #: Where `print()` on *this* thread goes. Thread-scoped where the log handler
 #: is not, and the difference is not fussiness: a run lasts minutes, and a
 #: global stdout tee spent all of them absorbing every unrelated print in the
@@ -138,6 +146,7 @@ def capture(buffer: Bounded | None = None):
     handler = _Handler(buffer)
     handler.setFormatter(
         logging.Formatter("%(levelname)s [%(name)s] %(message)s"))
+    handler.addFilter(lambda record: record.name != _MCP_LOGGER)
 
     # Both, and it is not belt-and-braces. `keyhac` is configured with
     # propagate=False (core/log.py), so a record from the documented

--- a/keyhac/mcp/server.py
+++ b/keyhac/mcp/server.py
@@ -56,6 +56,18 @@ ENDPOINT_FILE = "mcp.json"
 #: is a mistake or an attack, and reading it would be the damage.
 MAX_BODY = 1 << 20
 
+#: How much of one argument value the INFO line for a call shows.  Long enough
+#: to tell two calls on the same tool apart, short enough that
+#: `write_extension`'s source cannot push the rest of the console out of the
+#: ring buffer - the file it lands in is announced with a line count anyway.
+VALUE_CHARS = 60
+
+#: How much of one JSON-RPC message the DEBUG traffic lines show.  A
+#: `describe_screen` reply is a whole UI tree: the point of the traffic log is
+#: what was asked and roughly what came back, not a transcript that scrolls
+#: everything else out of the window.
+DETAIL_CHARS = 2000
+
 
 #: APPMODEL_ERROR_NO_PACKAGE - what GetCurrentPackageFullName answers when the
 #: calling process has no package identity, i.e. is not running from an MSIX
@@ -219,7 +231,16 @@ class _Handler(BaseHTTPRequestHandler):
         return secrets.compare_digest(header[len(prefix):], self.server.token)
 
     def _send(self, status: int, payload) -> None:
-        body = b"" if payload is None else json.dumps(payload).encode("utf-8")
+        # UTF-8 on the wire rather than `\uXXXX` escapes, which is what JSON is
+        # specified to be (RFC 8259 §8.1) and what the bridge already decodes
+        # the body as. A tool reply is a UI tree, so on a Japanese system it is
+        # mostly non-ASCII: escaping sent every one of those characters as six
+        # bytes instead of three, and the CJK case measured 1.77x. The compact
+        # separators beside it save a constant handful of bytes per reply - the
+        # padding is per field, not per character, so it is the escaping that
+        # was worth the change.
+        body = b"" if payload is None else json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -240,6 +261,22 @@ class Dispatcher:
         self.registry = registry
 
     def handle(self, request):
+        """One reply, with the whole exchange logged around it at DEBUG.
+
+        A wrapper so that every reply is logged from one place rather than at
+        each of `_handle`'s returns - and so a request that is not JSON-RPC at
+        all, which the dispatch below refuses before reading it, is still
+        visible as something that arrived. The INFO half of the console trail
+        is one line per *tool* call, in `_call`.
+        """
+        logger.debug(f"-> {_detail(request)}")
+        response = self._handle(request)
+        # A notification has no reply to log; the 202 is the whole answer.
+        if response is not None:
+            logger.debug(f"<- {_detail(response)}")
+        return response
+
+    def _handle(self, request):
         if not isinstance(request, dict) or request.get("jsonrpc") != "2.0":
             return _error(None, -32600, "not a JSON-RPC 2.0 request")
 
@@ -287,7 +324,101 @@ class Dispatcher:
             logger.debug(f"tool {name} failed", exc_info=True)
             text = f"{type(error).__name__}: {error}"
             is_error = True
+
+        # One INFO line per tool call, and only for tool calls: `initialize`,
+        # `tools/list` and the ping a client repeats while it is connected are
+        # handshake, and an audit trail nobody can read is not one. Logged on
+        # the way out rather than the way in, because the outcome is half of
+        # what the line is for - the access-log shape, not a progress display.
+        # A call that blocks by design (`get_action_result` waits) therefore
+        # reports when it returns, and what it was waiting for is already on
+        # the console: the action's own output goes there as it happens.
+        logger.info(f"{name}({_call_arguments(arguments)}) -> "
+                    f"{_elide(text, VALUE_CHARS) if is_error else f'{len(text)} chars'}")
         return {"content": [{"type": "text", "text": text}], "isError": is_error}
+
+
+def _call_arguments(arguments) -> str:
+    """`name='thing', wait=20` - what tells two calls on one tool apart.
+
+    Values are elided rather than dropped. Which module was written and which
+    window was read is the whole content of the audit line, and a tool whose
+    arguments are all long (`write_extension`) is exactly the one where seeing
+    the first words of them matters.
+    """
+    if not isinstance(arguments, dict):
+        return _elide(repr(arguments), VALUE_CHARS)
+    return ", ".join(f"{key}={_value(value)}" for key, value in arguments.items())
+
+
+def _value(value) -> str:
+    # Elided *inside* the quotes, so a shortened string still reads as one.
+    if isinstance(value, str) and len(value) > VALUE_CHARS:
+        return repr(_elide(value, VALUE_CHARS))
+    return repr(value)
+
+
+def _elide(text: str, limit: int) -> str:
+    """One console line, at most `limit` characters of it.
+
+    Newlines collapse rather than wrap: a traceback from a failing tool would
+    otherwise turn one audit line into thirty, and the whole of it is a DEBUG
+    line away.
+    """
+    line = " ".join(text.split())
+    return line if len(line) <= limit else line[:limit] + "..."
+
+
+def _detail(message) -> str:
+    """A JSON-RPC message as something a person can read, bounded.
+
+    **The envelope stays one compact line.** `jsonrpc`, `id` and the shape of
+    the result say almost nothing to a reader, and folding them over ten
+    indented lines would bury the part that does.
+
+    **The payload becomes a block.** That part is a `describe_screen` reply or
+    the module `write_extension` was handed, and inside JSON either arrives as
+    one line with `\\n` written out in it - a UI tree rendered as an unreadable
+    ribbon in a window that would have shown it perfectly well. So every string
+    with a newline in it is lifted out, leaving `<its.path>` where it sat, and
+    printed underneath as itself. Blocks follow in the order their placeholders
+    appear.
+
+    The console splits a record on its newlines and prefixes only the first
+    (`core/log.py`), so this lands as a header line and an indented body - the
+    shape a logged traceback already has there. `ensure_ascii` is off for the
+    same reason: a Japanese menu label is worth more as itself than as six
+    characters of `\\u30bb`.
+    """
+    blocks: list[str] = []
+
+    def lift(node, path):
+        if isinstance(node, str) and "\n" in node:
+            blocks.append(node)
+            return f"<{path}>"
+        if isinstance(node, dict):
+            return {key: lift(value, f"{path}.{key}" if path else str(key))
+                    for key, value in node.items()}
+        if isinstance(node, list):
+            return [lift(value, f"{path}[{index}]")
+                    for index, value in enumerate(node)]
+        return node
+
+    try:
+        envelope = json.dumps(lift(message, ""), default=repr,
+                              ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        envelope, blocks = repr(message), []
+    return "\n".join([_bounded(envelope)] + [_bounded(block) for block in blocks])
+
+
+def _bounded(text: str) -> str:
+    """`DETAIL_CHARS` of it, and how much was left. Per block rather than per
+    record: the cap is there to keep one reply from evicting the console's ring
+    buffer, and a reply's tree is the block."""
+    if len(text) <= DETAIL_CHARS:
+        return text
+    return f"{text[:DETAIL_CHARS]}... [{len(text) - DETAIL_CHARS} more characters]"
 
 
 def _result(request_id, result):

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -951,6 +951,12 @@ class _captured_log:
         self.handler = _Capture(self.buffer)
         self.handler.setFormatter(
             logging.Formatter("%(levelname)s [%(name)s] %(message)s"))
+
+        # Our own access log is not part of what the reload said, and a call
+        # arriving on another connection while this one runs would otherwise
+        # come back as if it were.
+        self.handler.addFilter(lambda record: record.name != logger.name)
+
         # Both, and it is not belt-and-braces. `keyhac` is configured with
         # propagate=False (core/log.py), so a record from the documented
         # getLogger() never reaches root - attaching only there captured

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -170,6 +170,142 @@ def test_a_failing_tool_reports_inside_the_result(dispatcher):
     assert "absent" in reply["result"]["content"][0]["text"]
 
 
+# -- the console trail -------------------------------------------------------
+
+def _rpc(dispatcher, name, arguments=None):
+    return dispatcher.handle({"jsonrpc": "2.0", "id": 9, "method": "tools/call",
+                              "params": {"name": name,
+                                         "arguments": arguments or {}}})
+
+
+def _info(caplog):
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+
+
+def _debug(caplog):
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+
+
+def test_every_call_is_one_info_line(dispatcher, caplog):
+    """The console is where an operator watches an open endpoint, and until
+    this it reported only the two writes - a session could read every window on
+    the screen and leave nothing behind."""
+    with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
+        _rpc(dispatcher, "describe_screen", {"app": "TestApp"})
+    assert len(_info(caplog)) == 1
+    assert _info(caplog)[0].startswith("describe_screen(app='TestApp')")
+
+
+def test_the_line_carries_the_outcome(dispatcher, caplog):
+    """Half of what the line is for: a call that was refused and one that
+    handed over a window are not the same event."""
+    with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
+        _rpc(dispatcher, "list_windows")
+        _rpc(dispatcher, "start_action", {"name": "absent"})
+    served, refused = _info(caplog)
+    assert served.endswith("chars")
+    assert "absent" in refused
+
+
+def test_a_failure_stays_on_one_line(dispatcher, caplog):
+    """A tool reports failure as text and some of that text is a traceback.
+    One call is one line, or the trail is unreadable in the window it is in."""
+    def explode(**_):
+        raise RuntimeError("first line\nsecond line\nthird line")
+
+    dispatcher.registry.tools["list_windows"].run = explode
+    with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
+        _rpc(dispatcher, "list_windows")
+    assert "\n" not in _info(caplog)[0]
+    assert "first line second line" in _info(caplog)[0]
+
+
+def test_a_long_argument_is_elided_not_dropped(writable, caplog):
+    """`write_extension` carries a whole module. Logging it whole would push
+    the rest of the session out of the console's ring buffer; logging only the
+    tool name would lose which module was written."""
+    source = "# " + "x" * 5000 + "\n"
+    with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
+        _rpc(Dispatcher(writable), "write_extension",
+             {"name": "thing", "source": source})
+    # Two lines here, saying different things: the tool announces the file it
+    # replaced, and the call line is the one under test.
+    line = next(m for m in _info(caplog) if m.startswith("write_extension("))
+    assert "name='thing'" in line
+    assert source not in line and len(line) < 300
+    assert "source='# xxx" in line, "and enough of it to recognise"
+
+
+def test_the_handshake_is_not_an_info_line(dispatcher, caplog):
+    """A client pings for as long as it stays connected. An audit trail nobody
+    can read is not one."""
+    with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
+        for method in ("initialize", "tools/list", "ping"):
+            dispatcher.handle({"jsonrpc": "2.0", "id": 1, "method": method})
+    assert _info(caplog) == []
+
+
+def test_debug_carries_the_whole_exchange(dispatcher, caplog):
+    with caplog.at_level(logging.DEBUG, logger="keyhac.MCP"):
+        _rpc(dispatcher, "describe_keymap")
+    sent = [m for m in _debug(caplog) if m.startswith("-> ")]
+    received = [m for m in _debug(caplog) if m.startswith("<- ")]
+    assert any("describe_keymap" in m for m in sent)
+    assert any("focus path" in m for m in received), "the reply, not just a shape"
+
+
+def test_the_debug_line_spends_no_characters_on_nothing(registry, caplog):
+    """Both of json.dumps's defaults inflate it: padded separators cost a
+    character per field, and ensure_ascii turns one Japanese label into six
+    characters each. `DETAIL_CHARS` is the budget they were spending."""
+    registry.keymap.node.name = "セカイブラウザ"
+    with caplog.at_level(logging.DEBUG, logger="keyhac.MCP"):
+        _rpc(Dispatcher(registry), "describe_screen")
+    reply = next(m for m in _debug(caplog) if m.startswith("<- "))
+    assert '{"jsonrpc":"2.0","id":9' in reply
+    assert "セカイブラウザ" in reply and "\\u30bb" not in reply
+
+
+def test_the_payload_reads_as_itself_not_as_an_escaped_ribbon(registry, caplog):
+    """A UI tree inside JSON is one line with `\\n` written out along it, which
+    is the one thing the console could have shown properly and did not. The
+    envelope stays on its line; the tree goes underneath as a tree."""
+    registry.keymap.node.dump = lambda: ("AXWindow 'Root'\n"
+                                         "  AXGroup 'Sidebar'\n"
+                                         "    AXButton 'Explorer'")
+    with caplog.at_level(logging.DEBUG, logger="keyhac.MCP"):
+        _rpc(Dispatcher(registry), "describe_screen")
+    envelope, *body = next(
+        m for m in _debug(caplog) if m.startswith("<- ")).splitlines()
+
+    assert "\\n" not in envelope, "the tree is lifted out, not written along it"
+    assert envelope.endswith('"isError":false}}'), "and the shape still shows"
+    assert "<result.content[0].text>" in envelope, "naming where it went"
+    assert body[:3] == ["AXWindow 'Root'",
+                        "  AXGroup 'Sidebar'",
+                        "    AXButton 'Explorer'"], "indentation is the tree"
+
+
+def test_a_debug_block_is_bounded(writable, caplog):
+    """The bound is per block rather than per record, because the block is what
+    would evict the ring buffer: `describe_screen` answers with a whole UI tree
+    and `write_extension` is handed a whole module."""
+    with caplog.at_level(logging.DEBUG, logger="keyhac.MCP"):
+        _rpc(Dispatcher(writable), "write_extension",
+             {"name": "thing", "source": "# " + "x" * 50_000 + "\n"})
+    envelope, block = next(
+        m for m in _debug(caplog) if m.startswith("-> ")).splitlines()
+    assert len(envelope) < 300, "the source is not in it"
+    assert len(block) < server_module.DETAIL_CHARS + 100
+    assert "more characters" in block
+
+
+def test_a_notification_logs_no_reply(dispatcher, caplog):
+    with caplog.at_level(logging.DEBUG, logger="keyhac.MCP"):
+        dispatcher.handle({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    assert not [m for m in _debug(caplog) if m.startswith("<- ")]
+
+
 # -- tools ------------------------------------------------------------------
 
 def test_list_windows_marks_the_focused_one(registry):
@@ -987,6 +1123,31 @@ def test_with_the_token_it_serves(server):
     assert reply["result"]["tools"]
 
 
+def test_the_reply_goes_out_as_utf8_not_escapes(server):
+    """A tool reply is a UI tree, so on a Japanese system it is mostly
+    non-ASCII, and `\\uXXXX` spends six bytes on each character UTF-8 carries in
+    three. Asserted on the bytes: a client would decode either form to the same
+    string, so only the wire shows it."""
+    server.registry.keymap.node.name = "セカイブラウザ"
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{server.port}/",
+        data=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                         "params": {"name": "describe_screen"}}).encode(),
+        headers={"Content-Type": "application/json",
+                 "Authorization": f"Bearer {server.token}"},
+        method="POST")
+    with urllib.request.urlopen(request, timeout=10) as reply:
+        body = reply.read()
+        # A Content-Length counted off a different string than the one written
+        # is a hang, not a wrong answer - urlopen would wait for bytes that
+        # never come. Reading the whole body under a timeout is that assertion.
+        assert int(reply.headers["Content-Length"]) == len(body)
+
+    assert "セカイブラウザ".encode() in body
+    assert b"\\u30bb" not in body
+    assert json.loads(body)["result"]["content"][0]["text"], "and it still parses"
+
+
 def _no_other_user_can_read(path):
     """Windows' answer to the 0600 question, asked of the mechanism it uses.
 
@@ -1266,6 +1427,39 @@ def test_the_bridge_reads_its_pipe_as_utf8(tmp_path, monkeypatch):
 
     sent = json.loads(forwarded[0].decode("utf-8"))
     assert sent["params"]["arguments"]["name"] == "メモ帳"
+
+
+def test_the_bridge_writes_its_pipe_as_utf8(tmp_path, monkeypatch):
+    """The other half of the same reconfigure, and it only became load-bearing
+    when the daemon stopped `\\uXXXX`-escaping its replies: until then every
+    body was ASCII whatever the pipe's code page was, so a cp932 stdout could
+    not fail on one. Now a reply carries the window titles it read."""
+    import io
+    from keyhac.mcp import bridge
+
+    endpoint = tmp_path / "mcp.json"
+    endpoint.write_text(json.dumps({"port": 1, "token": "t"}))
+    monkeypatch.setattr(bridge, "endpoint_path", lambda config=None: str(endpoint))
+    monkeypatch.setattr("sys.stdin", io.StringIO(
+        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping"}) + "\n"))
+
+    served = json.dumps({"jsonrpc": "2.0", "id": 1,
+                         "result": {"text": "メモ帳 - 無題"}},
+                        ensure_ascii=False).encode("utf-8")
+
+    class Reply:
+        def __enter__(self): return self
+        def __exit__(self, *exc): return False
+        def read(self): return served
+
+    monkeypatch.setattr(bridge.urllib.request, "urlopen",
+                        lambda prepared, timeout=None: Reply())
+    written = io.BytesIO()
+    monkeypatch.setattr("sys.stdout", io.TextIOWrapper(written, encoding="cp1252"))
+    bridge.main([])
+
+    relayed = json.loads(written.getvalue().decode("utf-8"))
+    assert relayed["result"]["text"] == "メモ帳 - 無題"
 
 
 def test_a_hollow_web_area_points_at_content_access(registry):
@@ -1573,5 +1767,25 @@ def test_an_unrelated_print_does_not_land_in_a_running_action(writable):
     peek = writable.call("get_action_result", {"name": "slow.Slow", "wait": 0})
     assert "started working" in peek, "the action's own print is captured"
     assert "NOT THE ACTION'S OUTPUT" not in peek
+    gate.set()
+    writable.call("get_action_result", {"name": "slow.Slow", "wait": 20})
+
+
+def test_the_call_log_does_not_land_in_a_running_action(writable):
+    """The same problem the print tee had, arriving by the other route: the log
+    handler is global on purpose, so one line per call would mean a model
+    polling a long run reading back the polls that read it."""
+    dispatcher = Dispatcher(writable)
+    gate = _slow_action(writable)
+    _rpc(dispatcher, "start_action", {"name": "slow.Slow"})
+    time.sleep(0.1)
+    _rpc(dispatcher, "get_action_result", {"name": "slow.Slow", "wait": 0})
+
+    peek = _rpc(dispatcher, "get_action_result",
+                {"name": "slow.Slow", "wait": 0})["result"]["content"][0]["text"]
+    assert "started working" in peek, "the action's own output is still captured"
+    # The report quotes get_action_result itself - it says how to ask again -
+    # so the marker is the log format, not the tool name.
+    assert "[keyhac.MCP]" not in peek
     gate.set()
     writable.call("get_action_result", {"name": "slow.Slow", "wait": 20})


### PR DESCRIPTION
The console reported the two writes and nothing else. An agent that spent an hour calling `describe_screen` and `read_text` across every window you had open finished with a console showing only the port it started on — and a tool that *failed* left even less, since the traceback went to DEBUG and the failure text went back to the model.

`doc/ai-integration.md`'s own argument for the switch is that the exposure "coincides with you sitting in front of the screen, watching a console that reports every write", and reading is the larger half of what the endpoint grants.

## The line

Every tool call now writes one INFO line — the tool, its arguments elided to 60 characters each, and the outcome, which is either a size or the failure:

```
INFO [keyhac.MCP] describe_screen(app='Chrome') -> 4812 chars
INFO [keyhac.MCP] start_action(name='absent') -> KeyError: 'no absent.py in ...'
```

Logged on the way out rather than the way in, because the outcome is half of what the line is for. A call that blocks by design (`get_action_result` waits) therefore reports when it returns — the access-log shape rather than a progress display — and what it was waiting for is already on the console, since an action's own output goes there as it happens.

Only tool calls. `initialize`, `tools/list` and the ping a client repeats for as long as it stays connected are handshake, and an audit trail nobody can read is not one. Those, and the whole of every request and reply, are at DEBUG.

## The leak it dragged in

The capture handler that collects an action's output for the model is global on the `keyhac` tree, deliberately — `core/capture.py` explains that a thread filter would drop exactly the `starting()`/`finished()` halves that say how the run ended.

One line per call would therefore have landed inside whichever action was running: a run lasts minutes and a model polls it, so `get_action_result` would have come back quoting the polls that read it. It is the failure the stdout tee already had, arriving by the other route, so `keyhac.MCP` records are now filtered out of action captures and out of `reload_config`'s.

## Also here

Driven out by reading the result in the console: the daemon spent its replies twice over. `json.dumps` escapes non-ASCII by default, so a UI tree read from a Japanese window went over the wire at six bytes per character where UTF-8 needs three.

| 32 KB reply | before | after | |
|---|---|---|---|
| ASCII only | 34300 B | 34289 B | 1.00× |
| all Japanese | 132100 B | 74489 B | **0.56×** |

The padded separators that started this are not the same order of thing: 11 bytes, per *field* rather than per character, so they do not scale with the tree at all. Neither costs tokens — the client decodes the envelope before the model sees the text — and loopback makes the rest memcpy time, so this is cheapness rather than a bottleneck. What makes it worth the diff is that it is one argument.

It does move a guard from defensive to load-bearing. e86ec9e reconfigured both of the bridge's pipes to UTF-8 and noted that "any non-ASCII reply would have failed to encode on the way back" — hypothetically, because every reply body was pure ASCII while the daemon escaped them. Now they are not, and stdout raises `UnicodeEncodeError` on a cp932 pipe without that reconfigure. Checked by removing it; pinned by a test.

## Reading it back

The log rendering went the other way. A tree inside JSON is one line with `\n` written out along it, which is the one thing a console window could have shown properly and did not. So every string carrying a newline is lifted out of the message, leaves `<its.path>` where it sat, and prints underneath as itself:

```
DEBUG [keyhac.MCP] <- {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"<result.content[0].text>"}],"isError":false}}
AXWindow 'my-projects (Workspace)'
  AXGroup 'my-projects (Workspace)'
    AXWebArea 'my-projects (Workspace)'
      AXStaticText = 'Diff editor'
```

The envelope stays compact on one line — `jsonrpc`, `id` and the shape of the result say nothing to a reader, and indenting them over ten lines would bury what does. It is general rather than a special case for `describe_screen`: `write_extension`'s argument reads as Python in the request direction. The `DETAIL_CHARS` cap moved to per block, since the block is the thing that could evict the console's 1000-line ring buffer.

## Verification

495 passed, 17 skipped — 13 tests new: the one line per call and its outcome, failures staying on one line, argument elision, the handshake's silence, both DEBUG directions and their bound, the block rendering keeping its indentation, the bytes on the wire with `Content-Length` still matching them, the bridge relaying a non-ASCII reply through a cp1252 pipe, and a running action's report no longer quoting the calls that read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
