### PR TITLE
Only the operator could take a module back out of extensions/

### DIFF
--- a/doc/ai-integration.md
+++ b/doc/ai-integration.md
@@ -420,6 +420,7 @@ coordinates, or bindings it never checked.
 | `list_extensions` | the files in `extensions/`, including helpers with no action class |
 | `read_extension` | read a module as it is on disk |
 | `write_extension` | save a module — the whole file |
+| `delete_extension` | retire a module — renamed to a backup beside it, not erased |
 | `reload_config` | re-read your `config.py` after you edit it, and report any error |
 
 None of these has a permission of its own, and that is the design rather than
@@ -508,7 +509,9 @@ don't type passwords or show private material while recording.
   is what rules out paths and traversal — and `config.py` itself. Neither is
   replaced silently: the previous version is kept as a `.bak-<timestamp>`
   beside it, and every write is logged to the console with a `+N/-M` line
-  count.
+  count. **Nothing is erased**, either: `delete_extension` retires a module by
+  renaming it to the same `.bak-<timestamp>`, so tidying up after a session is
+  undone by renaming it back.
 - **`write_config` is the one thing that outlives the hour.** Everything else
   an agent does here expires when the endpoint closes; a key binding written
   into `config.py` keeps working, which is the point of writing it. It is a

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -1154,8 +1154,8 @@ Against the layers in §5 and the sequence in §10:
 | Layer 2 — state reading | **Done**, both platforms. `keymap.ui` + `UINode`, the text layer, verified live on macOS and Windows. |
 | Layer 3 — execution safety | **Partial, and less so.** Waiting, read-back, **`Esc` cancellation** and **the executor** are in; the `max_workers=1` bug §2.1 named is gone. Per-step preconditions, checkpointing and idempotency remain *patterns the actions follow*, not framework: `Action.preconditions()` and dry-run/preview are **not built**. |
 | Layer 4 — action metadata | **Reduced to what was load-bearing.** The name is now the class's own `module.Class`, discovered rather than declared, so `register_action` went with the registry it fed (§15.2); the MCP tool schemas remain. No argument schema - these are instantiated with no arguments - and the description surface is the class docstring's first line. `list_actions` reports what is running and how each last ended, and `get_action_result` serves the run itself (§15.4). |
-| Layer 5 — artifact management | **Built, in a shape §5 did not anticipate.** `write_extension` puts a generated module in `extensions/`, and **every action class there is runnable** as `module.Class` with no `config.py` edit at all - both behind the endpoint's own switch, which now expires (§4.4, §15.2). Discovery is an **AST scan**, so listing never imports; that is what let it land without becoming the auto-execution `extensions/` has never done. `register_action` is gone, and what survives in `config.py` is the key binding. Still absent: partial reload (a file re-imports itself on mtime, so nothing has needed it). |
-| Topology A — MCP | **Done.** `keyhac/mcp/`: twelve tools over loopback HTTP with a per-start token, off unless the config asks; `keyhac-mcp-bridge` for Claude Desktop. See `doc/ai-integration.md`. |
+| Layer 5 — artifact management | **Built, in a shape §5 did not anticipate.** `write_extension` puts a generated module in `extensions/`, and **every action class there is runnable** as `module.Class` with no `config.py` edit at all - both behind the endpoint's own switch, which now expires (§4.4, §15.2). Discovery is an **AST scan**, so listing never imports; that is what let it land without becoming the auto-execution `extensions/` has never done. `register_action` is gone, and what survives in `config.py` is the key binding. `delete_extension` completes it from the other end - a rename into the same `.bak-` scheme, so the directory a fix loop clutters can be tidied without erasing anything (§15.2). Still absent: partial reload (a file re-imports itself on mtime, so nothing has needed it). |
+| Topology A — MCP | **Done.** `keyhac/mcp/`: eighteen tools over loopback HTTP with a per-start token, off unless the config asks; `keyhac-mcp-bridge` for Claude Desktop. See `doc/ai-integration.md`. |
 | Topology B — agent host | **Not built, and probably unnecessary** (§3.4). Nothing has needed runtime inference. |
 | `LLMAction` | **Still undecided, and the evidence is in.** Six actions, none needed inference. §3.4 said decide after hand-writing; the honest next step is deleting it. |
 
@@ -1310,6 +1310,29 @@ loop had not been exercised on: maintaining an action from an earlier session.
 Read and write share one fence (`_module_path`), and an oversized file is
 **refused rather than truncated** - half a read feeding a whole-file write is
 how the other half disappears.
+
+**`delete_extension` closes the set, and is a rename.** A loop that writes
+leaves a directory that accumulates: a module named before the shape was known,
+a helper split out and then folded back in, an attempt abandoned under a name
+nothing will ever import. Every one of those was the operator's to sweep up by
+hand, for no reason except that the write half had been built and the other had
+not. What made it easy to add is that the backup scheme was already there: the
+file goes to the same timestamped `.bak-`, under the same five-deep bound, so
+the tool that sounds destructive is the only one here that destroys nothing -
+and it needed no new fence, `_module_path` being the same rule read backwards.
+
+The one hazard is the one this deliberately does **not** handle. `config.py` is
+untouched, so deleting a module the operator has bound to a key stops their file
+loading - a failure that surfaces as key bindings that quietly stopped working,
+well after the call. Editing their file to match would be worse (it is
+`write_config`'s job, with them in the conversation, not a side effect of
+tidying `extensions/`), so the reply carries the warning instead: a loose
+`\bname\b` search of `config.py`, since `import thing`, `from thing import X`
+and a `thing.Action()` on a binding line are one signal and the errors are not
+symmetric - a false positive costs a sentence, a false negative costs a config
+that will not load. Live state is left alone for the same reason: an imported
+class keeps running out of memory, so a run started before the delete stays
+readable and cancellable and the operator's key works until they reload.
 
 **The registration half then landed too** — and the resolution came from
 noticing the note's framing was wrong a second time. It asks whether the

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -17,6 +17,12 @@ because the operator was otherwise the transport for every iteration of every
 fix - and because the manual step it replaces was never the review it
 resembled; nobody reads what they paste.
 
+`delete_extension` is that same fence, run in reverse, and it is a **rename**
+rather than an unlink: a module leaves `extensions/` as a timestamped `.bak-`
+beside itself. So the one tool here that sounds destructive destroys nothing,
+and the directory a fix loop leaves cluttered can be tidied without the operator
+being the transport for that either.
+
 `keyhac/mcp/extensions.py` is the other half of that: an action class in
 `extensions/` is runnable by `module.Class` without any `config.py` edit, and
 those classes are the whole of the action surface. There is no registry of named
@@ -31,8 +37,8 @@ switch was tried and undone - it left reading every open window as the
 long-lived half and writing as the short-lived one, which is backwards, since
 `describe_screen` is by far the larger exposure. So the statement of what a
 running endpoint grants is short and whole: while it is open, code the operator
-has not read can be written and run, and every window they have open can be
-read. Nothing types text or presses a key.
+has not read can be written, run and taken back out again, and every window they
+have open can be read. Nothing types text or presses a key.
 
 THREADS. Element access is main-thread-only and these run on the MCP server's
 threads, so every tool that touches the UI goes through `ui.on_main_thread` -
@@ -45,6 +51,7 @@ import difflib
 import keyword
 import logging
 import os
+import re
 import shutil
 import sys
 import threading
@@ -336,6 +343,20 @@ class ToolRegistry:
                                 "so send all of it every time."}},
                   "required": ["name", "source"]},
                  self.write_extension),
+            Tool("delete_extension",
+                 "Remove a module from ~/.keyhac/extensions/ - **renamed to a "
+                 "timestamped .bak- beside it rather than unlinked**, so the "
+                 "operator can put it back. For what an authoring session "
+                 "leaves behind: a module written under the wrong name, a "
+                 "helper that got folded back into the action. It does not "
+                 "touch config.py - so if that file imports the module, the "
+                 "reply says so, and taking those lines out is the next thing "
+                 "to offer.",
+                 {"type": "object", "properties": {
+                     "name": {**string, "description": "Module name, with no "
+                              "path and no .py suffix: \"open_issues\"."}},
+                  "required": ["name"]},
+                 self.delete_extension),
             Tool("reload_config",
                  "Reload ~/.keyhac/config.py and report what it said - use it "
                  "**after the operator edits that file**, to check their paste "
@@ -726,13 +747,22 @@ class ToolRegistry:
         """
         path = self._module_path(name)
         if not os.path.exists(path):
-            modules = sorted(
-                entry[:-3] for entry in _listdir(self.keymap.extensions_dir)
-                if entry.endswith(".py"))
-            return (f"no {name}.py in {self.keymap.extensions_dir}"
-                    + (f". There is: {', '.join(modules)}" if modules
-                       else " - the directory is empty."))
+            return self._no_module(name)
         return self._read_file(path)
+
+    def _no_module(self, name: str) -> str:
+        """What a tool says about a module that is not there.
+
+        With the directory listed, because the near-misses are what this is
+        usually hit by: a module addressed by its class name, or by the name it
+        had before it was rewritten.
+        """
+        modules = sorted(
+            entry[:-3] for entry in _listdir(self.keymap.extensions_dir)
+            if entry.endswith(".py"))
+        return (f"no {name}.py in {self.keymap.extensions_dir}"
+                + (f". There is: {', '.join(modules)}" if modules
+                   else " - the directory is empty."))
 
     def write_extension(self, name: str, source: str) -> str:
         """Save a module into ``extensions/``, while the window is open.
@@ -761,6 +791,80 @@ class ToolRegistry:
             return result[:-1] + " - start_action picks it up as soon as it "\
                                  "is named, no reload needed."
         return result
+
+    def delete_extension(self, name: str) -> str:
+        """Retire a module from `extensions/` - by renaming, never unlinking.
+
+        **The same move `write_extension` already makes on every replace**,
+        applied to the last version instead of a superseded one: the file goes
+        to a timestamped `.bak-` beside itself, under the same five-deep bound.
+        The argument for keeping backups there holds harder here - a replaced
+        module at least leaves its successor to read the intent off, and a
+        deleted one leaves nothing - so this must not be the single operation
+        that cannot be walked back.
+
+        **`config.py` is untouched, and that is where a delete can still
+        hurt.** A module the operator has bound to a key is imported by their
+        file at every load, so removing it stops that file loading - and the
+        failure surfaces as key bindings that quietly stopped working, well
+        after this call and nowhere near it. Doing it anyway and *saying so* is
+        the right shape: their file is edited by `write_config`, with them in
+        the conversation, not as a side effect of tidying `extensions/`.
+
+        **Live state is deliberately left alone.** A class already imported
+        keeps running out of memory, so an action started before this stays
+        readable through `get_action_result` and stoppable through
+        `cancel_action`, and the operator's key goes on working until they
+        reload. Nothing here is trying to make the deletion take effect faster
+        than the file system says it did.
+        """
+        try:
+            path = self._module_path(name)
+        except ValueError as error:
+            return f"nothing deleted: {error}"
+        if not os.path.exists(path):
+            return self._no_module(name)
+
+        backup = path + time.strftime(".bak-%Y%m%d-%H%M%S")
+        try:
+            # replace() rather than rename(): the suffix has one-second
+            # resolution, so writing a module and deleting it inside the same
+            # second collides - and on Windows rename() would raise there,
+            # turning a bounded loss (one backup of two, holding versions a
+            # second apart) into a refusal.
+            os.replace(path, backup)
+        except OSError as error:
+            return f"nothing deleted: {error}"
+        _prune_backups(path)
+
+        # Same reason write_extension logs: a file can leave the directory
+        # without appearing in the conversation, and the console line is what
+        # tells the operator watching it that one did.
+        logger.info(f"Deleted {path} (kept {os.path.basename(backup)}).")
+        return (f"deleted {name}.py - kept as {os.path.basename(backup)} "
+                f"beside it, so renaming that back undoes this."
+                + self._config_mentions(name))
+
+    def _config_mentions(self, name: str) -> str:
+        """A warning to hang off a delete when `config.py` names the module.
+
+        Searched rather than parsed, and deliberately loose: `import thing`,
+        `from thing import Action` and a `thing.Action()` on a binding line are
+        all the same signal, and the two errors are not symmetric. A false
+        positive costs a sentence the model reads and drops; a false negative
+        costs the operator a `config.py` that stops loading, hours later.
+        """
+        try:
+            with open(self.keymap.config_path, encoding="utf-8") as handle:
+                source = handle.read()
+        except OSError:
+            return ""
+        if not re.search(rf"\b{re.escape(name)}\b", source):
+            return ""
+        return (f" NOTE: config.py mentions {name}, so it is probably importing "
+                f"what is no longer there - the operator's next reload would "
+                f"fail and take their key bindings with it. Read it and offer "
+                f"to take those lines out.")
 
     def reload_config(self) -> str:
         # Cached instances are deliberately *not* dropped here. Staleness is

--- a/keyhac/skills/keyhac-action-authoring/SKILL.md
+++ b/keyhac/skills/keyhac-action-authoring/SKILL.md
@@ -215,6 +215,15 @@ that has never executed is a guess.
 5. Read, fix, and go back to 1. Nothing in this loop needs the operator.
 6. **When it works**, hand them the `configure()` block so they can name it and
    bind a key. Say plainly that this last step is theirs.
+7. **Clean up what the loop left behind.**
+   `delete_extension("wrong_name")` retires a module — it renames it to a
+   `.bak-` beside itself rather than erasing it, so this is reversible. Use it
+   for a module you wrote under a name you then abandoned, or a helper you
+   folded back into the action. **Only for what you created in this
+   conversation**: anything else in `extensions/` is the operator's, and it is
+   theirs to remove. If the reply says `config.py` mentions the module, read
+   that file and offer to take the lines out — leaving them there means their
+   next reload fails and their key bindings stop working.
 
 **The endpoint closes itself an hour after the operator opens it**, and every
 tool then stops answering at once — which reads like a dropped connection and is

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -523,6 +523,86 @@ def test_backups_are_bounded(writable, monkeypatch):
     assert backups == ["x = 2\n", "x = 3\n"]
 
 
+# -- delete_extension --------------------------------------------------------
+#
+# The property under all of these is that nothing leaves the disk: a delete is a
+# rename into the same `.bak-` scheme a replace already uses, so the tool that
+# sounds destructive is the one that destroys nothing.
+
+def test_deleting_renames_rather_than_unlinking(writable):
+    writable.call("write_extension", {"name": "thing", "source": "x = 1\n"})
+    result = writable.call("delete_extension", {"name": "thing"})
+
+    assert not (extensions(writable) / "thing.py").exists()
+    backups = list(extensions(writable).glob("thing.py.bak-*"))
+    assert [b.read_text() for b in backups] == ["x = 1\n"]
+    assert backups[0].name in result, "and the reply names what to rename back"
+
+
+def test_deleting_prunes_the_backups_like_a_write_does(writable, monkeypatch):
+    monkeypatch.setattr(tools_module, "_BACKUPS_KEPT", 2)
+    for revision in range(4):
+        monkeypatch.setattr(tools_module.time, "strftime",
+                            lambda fmt, r=revision: f".bak-2026080{r}-000000")
+        writable.call("write_extension",
+                      {"name": "thing", "source": f"x = {revision}\n"})
+    monkeypatch.setattr(tools_module.time, "strftime",
+                        lambda fmt: ".bak-20260809-000000")
+    writable.call("delete_extension", {"name": "thing"})
+
+    kept = sorted(p.read_text()
+                  for p in extensions(writable).glob("thing.py.bak-*"))
+    assert kept == ["x = 2\n", "x = 3\n"], "the deleted version is the newest"
+
+
+@pytest.mark.parametrize("name", ["../config", "sub/thing", "thing.py", ".."])
+def test_deleting_is_fenced_by_the_same_module_name_rule(writable, name):
+    write_action(writable, name="present", source="x = 1\n")
+    result = writable.call("delete_extension", {"name": name})
+    assert "cannot be a module name" in result
+    assert (extensions(writable) / "present.py").exists()
+
+
+def test_deleting_something_that_is_not_there_says_what_is(writable):
+    write_action(writable, name="present", source="x = 1\n")
+    result = writable.call("delete_extension", {"name": "absent"})
+    assert "no absent.py" in result and "present" in result
+
+
+def test_deleting_a_module_the_config_imports_says_so(configurable, tmp_path):
+    """The one way a delete can still hurt: config.py is not touched, so a
+    module bound to a key takes the operator's whole file down at the next
+    load - hours later, nowhere near this call."""
+    (tmp_path / "config.py").write_text(
+        "def configure(keymap):\n    import thing\n")
+    write_action(configurable, name="thing", source="x = 1\n")
+    write_action(configurable, name="other", source="x = 1\n")
+
+    assert "config.py mentions thing" in \
+        configurable.call("delete_extension", {"name": "thing"})
+    assert "config.py" not in \
+        configurable.call("delete_extension", {"name": "other"})
+
+
+def test_the_delete_is_announced_on_the_console(writable, caplog):
+    """A file can leave the directory without appearing in the conversation."""
+    write_action(writable, name="thing", source="x = 1\n")
+    with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
+        writable.call("delete_extension", {"name": "thing"})
+    assert any("Deleted" in r.getMessage() and "thing.py" in r.getMessage()
+               for r in caplog.records)
+
+
+def test_a_deleted_module_stops_being_listed(writable):
+    write_action(writable, name="thing")
+    assert "thing.OpenIssues" in writable.call("list_actions", {})
+
+    writable.call("delete_extension", {"name": "thing"})
+    assert "thing.OpenIssues" not in writable.call("list_actions", {})
+    assert "thing.py" not in writable.call("list_extensions", {}), \
+        "and the backup beside it is not a .py, so nothing importable is left"
+
+
 def test_the_write_is_announced_on_the_console(writable, caplog):
     with caplog.at_level(logging.INFO, logger="keyhac.MCP"):
         writable.call("write_extension", {"name": "thing", "source": "x = 1\n"})


### PR DESCRIPTION
The write half of the authoring loop was built and the other half was not, so a directory that only ever grows was the shape it left behind: a module named before the action's shape was known, a helper split out and then folded back in, an attempt abandoned under a name nothing will ever import. Every one of those was the operator's to sweep up by hand — for no reason except that nobody had written the tool.

## The tool

`delete_extension("scratch")` retires a module, and it is a **rename rather than an unlink**. The file goes to the same timestamped `.bak-` a replace already writes, under the same five-deep bound, so the one tool here that sounds destructive destroys nothing — and the reply names the backup, because renaming it back is the undo:

```
deleted scratch.py - kept as scratch.py.bak-20260809-122022 beside it, so renaming that back undoes this.
```

It needed no new fence: `_module_path` is the existing rule read backwards, so `../config`, `sub/thing` and `thing.py` are refused before anything is touched. `os.replace` rather than `os.rename`, because the suffix has one-second resolution — writing a module and deleting it inside the same second collides, and `rename()` would raise there on Windows, turning a bounded loss (one backup of two, holding versions a second apart) into a refusal.

## The hazard it does not handle, on purpose

`config.py` is untouched. A module the operator has bound to a key is imported by their file at every load, so deleting it stops that file loading — surfacing as key bindings that quietly stopped working, well after the call and nowhere near it.

Editing their file to match would be worse: that is `write_config`'s job, with them in the conversation, not a side effect of tidying `extensions/`. So the reply carries the warning instead:

```
deleted open_issues.py - kept as open_issues.py.bak-20260809-122022 beside it, so renaming
that back undoes this. NOTE: config.py mentions open_issues, so it is probably importing what
is no longer there - the operator's next reload would fail and take their key bindings with it.
Read it and offer to take those lines out.
```

A loose `\bname\b` search, deliberately: `import thing`, `from thing import X` and a `thing.Action()` on a binding line are one signal, and the errors are not symmetric — a false positive costs a sentence the model drops, a false negative costs a config that will not load.

Live state is left alone for the same reason. An imported class keeps running out of memory, so a run started before the delete stays readable through `get_action_result` and stoppable through `cancel_action`, and the operator's key works until they reload. Nothing here tries to make the deletion take effect faster than the file system says it did.

The console gets its line — `Deleted <path> (kept <backup>)` — on the argument `write_extension`'s line was added under: a file can leave the directory without appearing in the conversation.

## Scope, which the tool cannot enforce

The skill gained a step 7 that says it instead: clean up what *this conversation* created, and nothing else in `extensions/`, which is the operator's.

`doc/ai-integration.md` gains the tool row and the sentence that nothing is erased; the dev note records the `config.py` trade. Its Topology A row said "twelve tools" and had been stale since the `run_action` split — it is eighteen.

## Verification

505 passed, 17 skipped — 11 tests new: the rename rather than the unlink, pruning across a write-then-delete run, the module-name fence, the missing-module reply listing what is there, the `config.py` warning firing and not misfiring, the console line, and a deleted module leaving both `list_actions` and `list_extensions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
