### PR TITLE
Five low-hanging issues: a lost focus mark, a false quirk, two skill rules, a docstring

### DIFF
--- a/doc/config-api.md
+++ b/doc/config-api.md
@@ -701,7 +701,8 @@ Available as ``keymap.focus``, and passed to every ``custom_condition_func``.
  
  - <b>`app_name`</b>:  Process/exe base name without extension (Windows), or the  localized application name (macOS). 
  - <b>`pid`</b>:  Process id of the focused application. 
- - <b>`window_title`</b>:  Title of the focused window. 
+ - <b>`window_title`</b>:  Title of the focused window.  On macOS it is captured  during the focus-path walk and carries the path's transliteration  of fnmatch special characters ("(" and "[" become "<", ")" and 
+ - <b>`"]" become ">", and "/", "*", "?", "`</b>: " each become "-"); on Windows it is the raw title.  A ``title=`` pattern containing one of those characters must match the escaped spelling on macOS - or use a "*" wildcard across it, which works on both. 
  - <b>`class_name`</b>:  Win32 window class name (Windows only; None on macOS). 
  - <b>`path`</b>:  Focus path string - on macOS the AX focus path  ("/AXApplication(Xcode)/AXWindow(...)..."), on Windows a  synthesized "/{app_name}/{class_name}({title})" (provisional  format). 
  - <b>`element`</b>:  The focused *semantic* element - an AX UIElement (macOS) or a  UI Automation UIElement (Windows).  Same shape on both  (get_attribute_names(), get_attribute_value(), get_action_names(),  perform_action(), parent()), but each uses its own OS's  vocabulary of attribute names, "AXRole" versus "ControlType".  Portable code uses app_name / window_title / class_name and the  focus path instead. 

--- a/keyhac/mcp/server.py
+++ b/keyhac/mcp/server.py
@@ -76,7 +76,7 @@ _NO_PACKAGE = 15700
 
 
 def running_packaged() -> bool:
-    """Whether this process has MSIX package identity (the Store install).
+    """Whether this process has MSIX package identity (Store or sideloaded).
 
     Asked of Windows rather than inferred from the path, because it is exactly
     the condition that matters: a process *with* identity may run the binaries

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -58,6 +58,7 @@ import threading
 import time
 
 from keyhac.core import capture, log
+from keyhac.core.focus import FOCUS_PATH_TRANS_TABLE
 from keyhac.mcp import extensions
 
 logger = log.getLogger("MCP")
@@ -392,12 +393,23 @@ class ToolRegistry:
         return window
 
     def list_windows(self) -> str:
+        # On macOS Focus.window_title is captured off the focus-path walk and
+        # arrives transliterated (FOCUS_PATH_TRANS_TABLE: "(" -> "<", ":" ->
+        # "-", ...); enumerated window titles are raw.  Normalizing both sides
+        # makes the comparison mean "same window" on both OSes - the table
+        # maps onto characters it never maps from, so re-applying it to an
+        # already-escaped title changes nothing.  Issue #73.
+        def normalize(title):
+            return title.translate(FOCUS_PATH_TRANS_TABLE) if title else title
+
         def read():
             focus = self.keymap.focus
-            focused = (focus.app_name, focus.window_title) if focus else (None, None)
+            focused = ((focus.app_name, normalize(focus.window_title))
+                       if focus else (None, None))
             lines = []
             for window in self.keymap.list_windows():
-                mark = "*" if (window.app_name, window.title) == focused else " "
+                mark = ("*" if (window.app_name, normalize(window.title)) == focused
+                        else " ")
                 lines.append(f"{mark} {window.app_name or '?'}: "
                              f"{window.title or '(untitled)'}")
             return lines

--- a/keyhac/platform/base.py
+++ b/keyhac/platform/base.py
@@ -37,7 +37,13 @@ class Focus:
         app_name: Process/exe base name without extension (Windows), or the
             localized application name (macOS).
         pid: Process id of the focused application.
-        window_title: Title of the focused window.
+        window_title: Title of the focused window.  On macOS it is captured
+            during the focus-path walk and carries the path's transliteration
+            of fnmatch special characters ("(" and "[" become "<", ")" and
+            "]" become ">", and "/", "*", "?", ":" each become "-"); on
+            Windows it is the raw title.  A ``title=`` pattern containing
+            one of those characters must match the escaped spelling on
+            macOS - or use a "*" wildcard across it, which works on both.
         class_name: Win32 window class name (Windows only; None on macOS).
         path: Focus path string - on macOS the AX focus path
             ("/AXApplication(Xcode)/AXWindow(...)..."), on Windows a

--- a/keyhac/skills/keyhac-action-authoring/SKILL.md
+++ b/keyhac/skills/keyhac-action-authoring/SKILL.md
@@ -104,7 +104,7 @@ one run, not the branch they would have taken on a different item. Turn those
 into questions first — demonstration → clarifying questions → generation, never
 demonstration → generation.
 
-## The seven hard rules
+## The eight hard rules
 
 Each of these was a real failure, not a preference. Breaking one produces code
 that looks correct and is not.
@@ -144,6 +144,14 @@ that looks correct and is not.
    which is exactly the failure this class of action exists to avoid.
 7. **Bound every loop that follows a link.** A "Next" that links to itself
    otherwise runs until the operator gives up.
+8. **Close only what you can identify as yours.** With a pre-existing tab of
+   the same site already open, "close the tab" is ambiguous - and pressing a
+   close button on a guess has the operator's work on the other side. The
+   same holds for windows, temporary files, records you created. Record an
+   identity for what you open - a title you set, a value only you would have
+   written - and clean up only what matches it. An action that cannot
+   identify the resource it created must not clean up: stop and say so
+   instead, before anything is closed.
 
 ## Where the file goes
 
@@ -303,6 +311,7 @@ Check the generated action against this list, and fix rather than explain:
 - [ ] Results accumulate outside the failing scope, and are written per item
 - [ ] A second run does not duplicate the first
 - [ ] Loops are bounded
+- [ ] Cleanup closes only what the action itself opened, identified as its own
 - [ ] It says what to redo when it stops
 
 ## What belongs in the user's prompt, not in your questions

--- a/keyhac/skills/keyhac-action-authoring/SKILL.md
+++ b/keyhac/skills/keyhac-action-authoring/SKILL.md
@@ -110,9 +110,12 @@ Each of these was a real failure, not a preference. Breaking one produces code
 that looks correct and is not.
 
 1. **Never `sleep`.** Wait for something specific: an element appearing, a
-   value changing, a page label differing from the one you captured before
-   clicking. `sleep` passes on your machine and fails on a slower one - and on
-   a faster one it fails *silently*, acting on a screen that has not arrived.
+   label reading what the screen *should* now show. Name the target state,
+   never "different from what I captured before clicking" - a transform can
+   be the identity (translating `kt` returns `kt`), and a wait for the value
+   to *change* then never returns even though the screen is already correct.
+   `sleep` passes on your machine and fails on a slower one - and on a faster
+   one it fails *silently*, acting on a screen that has not arrived.
 2. **Never coordinates, and address by structure when names run out.**
    `identifier` first *when it is a real name* - a DOM id or an AutomationId.
    macOS `AXIdentifier` values like `_NS:746` are nib serial numbers: ignore

--- a/keyhac/skills/keyhac-action-authoring/references/practice.md
+++ b/keyhac/skills/keyhac-action-authoring/references/practice.md
@@ -89,6 +89,15 @@ window.wait_until_gone(identifier="dialog-title")     # 3: gone
 
 Beat 3 is the one that breaks iteration when omitted.
 
+**Wait for the state you expect, not for the old state to change.** "It
+differs from what I captured" and "the result arrived" coincide only when the
+new value happens to differ: a transform can be the identity - a translation
+whose output equals its input - and a wait on *difference* then never returns,
+with the screen already correct the whole time. This is the read-back rule
+aimed at presses: `set_text` verifies by reading back the value it wrote, not
+by noticing the field changed, and a press whose outcome matters is verified
+the same way - state the expected value in the condition.
+
 ## Reading text the tree cannot reach
 
 ```python

--- a/keyhac/skills/keyhac-action-authoring/references/quirks.md
+++ b/keyhac/skills/keyhac-action-authoring/references/quirks.md
@@ -3,7 +3,7 @@
 Every entry here was found by running against a real application, and each one
 produces code that looks correct and silently is not. Read this before
 debugging something that "should work". Measured on macOS 15 / Safari 18 /
-Chrome, 2026-08-06 and 07, and on Windows 11 Home 10.0.26200 / Notepad,
+Chrome, 2026-08-06 to 08, and on Windows 11 Home 10.0.26200 / Notepad,
 2026-08-07.
 
 Entries prefixed **Windows:** or **Native macOS:** apply to that platform only.
@@ -133,11 +133,29 @@ a single shot.
 
 ## Native macOS: identifiers are serial numbers
 
-`AXDOMIdentifier` in web content is a real name. AppKit's `AXIdentifier` is
-usually `_NS:746` - a nib ordinal that changes when the window is edited and
-means nothing to a reader. **"Prefer identifier" holds for DOM ids and
-AutomationIds, and is actively wrong for `_NS:*`.** Address native controls by
-name, and fall back to structure.
+`AXDOMIdentifier` in web content is usually a real name - though not always;
+see the next entry. AppKit's `AXIdentifier` is usually `_NS:746` - a nib
+ordinal that changes when the window is edited and means nothing to a reader.
+**"Prefer identifier" holds for DOM ids and AutomationIds that name something,
+and is actively wrong for `_NS:*`.** Address native controls by name, and fall
+back to structure.
+
+## A DOM id can be a serial number too
+
+Google Translate's language chips carry ids `#i14`-`#i21`, and the id→language
+mapping is reassigned on every page load, ordered by recently used languages:
+
+```
+load 1:  #i15='英語'    #i16='日本語'
+load 2:  #i15='日本語'  #i16='英語'
+```
+
+So "DOM ids are real names" is a habit of well-built pages, not a property of
+the platform - and a generated id is not marked as generated; `i15` looks no
+more synthetic than `q` looks hand-written. Before an action relies on what an
+id *means*, read the same screen twice - reload between reads - and confirm
+the id→content mapping survived. If it did not, address the element by name or
+visible text and treat the id as noise. Measured twice, 2026-08-08.
 
 ## Native macOS: a field's label is its sibling
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -312,6 +312,23 @@ def test_list_windows_marks_the_focused_one(registry):
     assert "* TestApp: Main" in registry.call("list_windows", {})
 
 
+def test_the_mark_survives_a_title_the_focus_path_escaped():
+    # On macOS Focus.window_title is transliterated by FOCUS_PATH_TRANS_TABLE
+    # ("(" -> "<", ":" -> "-", ...) while enumerated titles stay raw; the
+    # focused window was never marked when its title contained any of
+    # ( ) [ ] / * ? : - which is most editor and browser titles.  Issue #73.
+    from keyhac.core.focus import FOCUS_PATH_TRANS_TABLE
+    raw = "ai-integration.md (Working Tree) — keyhac"
+    keymap = FakeKeymap()
+    keymap.focus.app_name = "Code"
+    keymap.focus.window_title = raw.translate(FOCUS_PATH_TRANS_TABLE)
+    keymap.list_windows = lambda: [FakeWindow("Finder", "(untitled)"),
+                                   FakeWindow("Code", raw)]
+    out = ToolRegistry(keymap).call("list_windows", {})
+    assert f"* Code: {raw}" in out
+    assert "* Finder" not in out
+
+
 def test_describe_screen_dumps_the_tree(registry):
     assert "AXWindow" in registry.call("describe_screen", {})
 


### PR DESCRIPTION
One commit per issue, most-severe first:

- **#73** — `list_windows` never marked the focused window on macOS when the
  title contained `( ) [ ] / * ? :`. Both sides of the comparison now go
  through `FOCUS_PATH_TRANS_TABLE` (idempotent, and a no-op pair on Windows),
  so the mark means "same window" on both OSes. Took the issue's first fix
  path — the comparison, not the capture — since changing what the released
  `Focus.window_title` field holds belongs in a release that says so. The
  field's platform difference is now documented (config-api.md regenerated),
  and the regression test is the one the issue asked for.
- **#58** — quirks.md stated that web-content DOM ids are real names; Google
  Translate's per-load `#i14`–`#i21` reassignment disproves it. New entry with
  the measured counterexample and the read-twice check.
- **#59** — hard rule 1 taught waiting for the screen to *differ* from a
  captured value, which never returns when the transform is the identity
  (`kt` → `kt`). Rule 1 and practice.md now say: wait for the value the screen
  should be showing.
- **#60** — new hard rule 8: an action that cannot identify the resource it
  created must not clean up.
- **#64** — `running_packaged()` said "(the Store install)"; it answers for
  package identity, not provenance. Now "(Store or sideloaded)".

Full suite: 509 passed, 17 skipped (platform/live). `make api-reference-check`
passes.

Fixes #58, fixes #59, fixes #60, fixes #64, fixes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)