### PR TITLE
MCP low-hanging fixes: truncation shape, search bounds, log-level filter

### DIFF
--- a/keyhac/core/capture.py
+++ b/keyhac/core/capture.py
@@ -244,12 +244,25 @@ class ActionRun:
         with _finished:
             _finished.notify_all()
 
-    def report(self) -> str:
-        """The whole of what a caller came back for."""
+    def report(self, level: str | None = None, tail: int | None = None) -> str:
+        """The whole of what a caller came back for.
+
+        Args:
+            level: Lowest log severity to include - "DEBUG", "INFO", "WARNING",
+                "ERROR" or "CRITICAL".  None keeps everything.  Filters only
+                captured *log* lines (recognised by the "LEVEL [logger]" shape
+                the capture formatter writes); print() output, the status head
+                and the traceback always come through.
+            tail: Only the last `tail` lines of the output.  None keeps all of
+                it.
+
+        Both cuts announce themselves in the output, so a caller reading a
+        filtered report knows there was more and how to get it.
+        """
         head = (f"{self.name}: {self.status} after {self.seconds:.1f}s"
                 if not self.running else
                 f"{self.name}: still running after {self.seconds:.1f}s")
-        body = self.output.getvalue().strip()
+        body = _trimmed(self.output.getvalue().strip(), level, tail)
         parts = [head]
         if body:
             parts.append(body)
@@ -259,6 +272,52 @@ class ActionRun:
             parts.append("(call get_action_result again for the rest, or "
                          "cancel_action to stop it)")
         return "\n\n".join(parts)
+
+
+#: Severities in order, as the capture formatter opens a log line with them
+#: ("DEBUG [keyhac.Keymap] PASSTHRU : ...").  What `report(level=)` names and
+#: what the line filter matches on.
+_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def _trimmed(body: str, level: str | None, tail: int | None) -> str:
+    """`body` with low-severity log lines dropped and only the tail kept.
+
+    Issue #71: a run that types its way through a form leaves thousands of
+    keymap DEBUG lines around the two INFO lines that say what happened, and
+    the model reading the report pays for all of them.  Filtered at read time
+    rather than capture time, so asking again with `level="DEBUG"` can still
+    produce the lines an INFO-level read hid.
+
+    Matched on the "LEVEL [" opening the capture formatter writes.  A
+    multi-line log record loses only its first line - the continuation lines
+    are indistinguishable from print() output, which must never be dropped.
+    """
+    notes = []
+    if level is not None:
+        name = str(level).upper()
+        if name not in _LEVEL_NAMES:
+            raise ValueError(f"level must be one of "
+                             f"{', '.join(_LEVEL_NAMES)}, not {level!r}")
+        drop = tuple(f"{below} [" for below in
+                     _LEVEL_NAMES[:_LEVEL_NAMES.index(name)])
+        if drop and body:
+            lines = body.splitlines()
+            kept = [line for line in lines if not line.startswith(drop)]
+            if len(kept) < len(lines):
+                notes.append(f"[{len(lines) - len(kept)} log line(s) below "
+                             f"{name} hidden - level='DEBUG' returns "
+                             f"everything]")
+                body = "\n".join(kept)
+    if tail is not None:
+        if tail < 1:
+            raise ValueError("tail must be a positive number of lines")
+        lines = body.splitlines()
+        if len(lines) > tail:
+            notes.append(f"[showing the last {tail} of {len(lines)} lines - "
+                         f"omit tail= for all of them]")
+            body = "\n".join(lines[-tail:])
+    return "\n".join(notes + ([body] if body else []))
 
 
 def start_run(name: str) -> ActionRun:

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -57,7 +57,7 @@ import sys
 import threading
 import time
 
-from keyhac.core import capture, log
+from keyhac.core import capture, log, uitree
 from keyhac.core.focus import FOCUS_PATH_TRANS_TABLE
 from keyhac.mcp import extensions
 
@@ -94,6 +94,28 @@ def _listdir(directory: str) -> list[str]:
         return os.listdir(directory)
     except OSError:
         return []
+
+
+def _truncation_shape(nodes: list, max_depth: int, max_nodes: int) -> str:
+    """The shape of what a bounded walk cut off, so the next call can be
+    sized instead of guessed (issue #54).
+
+    Which bound did the cutting is readable off each cut point: a node
+    truncated at `max_depth` was cut by the depth bound, anywhere shallower
+    by the node budget.  The walker already knew all of these numbers; this
+    just stops discarding them.
+    """
+    cut = [node for node in nodes if node.truncated]
+    by_depth = sum(1 for node in cut if node.depth >= max_depth)
+    by_budget = len(cut) - by_depth
+    bounds = []
+    if by_depth:
+        bounds.append(f"{by_depth} by max_depth={max_depth}")
+    if by_budget:
+        bounds.append(f"{by_budget} by the max_nodes={max_nodes} budget")
+    return (f"reported {len(nodes)} node(s), cut off at {len(cut)} point(s) "
+            f"({', '.join(bounds)}); deepest level reached: "
+            f"{max(node.depth for node in nodes)}")
 
 
 def _running_action(name: str):
@@ -203,7 +225,15 @@ class ToolRegistry:
                      "text": {**string, "description":
                               "Matches label and content together."},
                      "limit": {**integer, "description": "Maximum matches "
-                               "to report (default 20)."}}},
+                               "to report (default 20)."},
+                     "max_depth": {**integer, "description": "How deep to "
+                                   f"search (default {uitree.DEFAULT_MAX_DEPTH}"
+                                   "). Web content can nest controls 30+ "
+                                   "levels down; a no-match reply says when "
+                                   "this bound cut the search short."},
+                     "max_nodes": {**integer, "description": "Node budget for "
+                                   "the search (default "
+                                   f"{uitree.DEFAULT_MAX_NODES})."}}},
                  self.find_elements),
             Tool("read_text",
                  "Read an element's whole text content - a terminal's "
@@ -265,7 +295,15 @@ class ToolRegistry:
                               "module.Class, from list_actions."},
                      "wait": {**integer, "description":
                               "Seconds to wait for it to finish (default 30, "
-                              "0 to look without waiting)."}},
+                              "0 to look without waiting)."},
+                     "level": {**string, "description":
+                               "Lowest log severity to return: DEBUG, INFO, "
+                               "WARNING or ERROR (default INFO, which hides "
+                               "the per-keystroke DEBUG stream; print() "
+                               "output always comes through)."},
+                     "tail": {**integer, "description":
+                              "Only the last N lines of the output (default: "
+                              "all of it)."}},
                   "required": ["name"]},
                  self.get_action_result),
             Tool("cancel_action",
@@ -432,8 +470,9 @@ class ToolRegistry:
 
     def describe_screen(self, app=None, title=None, max_depth=14,
                         max_nodes=DEFAULT_MAX_NODES, roles=None) -> str:
+        max_depth, max_nodes = int(max_depth), int(max_nodes)
         window = self._window(app, title)
-        tree = window.reread(max_depth=int(max_depth), max_nodes=int(max_nodes),
+        tree = window.reread(max_depth=max_depth, max_nodes=max_nodes,
                              roles=roles)
         nodes = list(tree.walk())
         text = tree.dump()
@@ -461,25 +500,58 @@ class ToolRegistry:
                      f"essentially nothing. Check list_windows for a better "
                      f"target.]")
         elif any(node.truncated for node in nodes):
-            text += ("\n\n[truncated: raise max_nodes/max_depth, or narrow "
-                     "with roles=, before concluding this is the whole screen]")
+            # With the shape of the cut, not just the fact of one (issue #54):
+            # "raise max_nodes" without saying from what left the next value a
+            # guess, and a measured session guessed twice.
+            text += (f"\n\n[truncated: "
+                     f"{_truncation_shape(nodes, max_depth, max_nodes)}. "
+                     f"Raise the bound that did the cutting, or narrow with "
+                     f"roles=, before concluding this is the whole screen]")
         return text
 
-    def find_elements(self, app=None, title=None, limit=20, **criteria) -> str:
+    def find_elements(self, app=None, title=None, limit=20, max_depth=None,
+                      max_nodes=None, **criteria) -> str:
         criteria = {k: v for k, v in criteria.items() if v is not None}
         if not criteria:
             raise ValueError("give at least one of role/name/value/"
                              "identifier/text")
         window = self._window(app, title)
-        matches = window.find_all(**criteria)
+        bounds = {}
+        if max_depth is not None:
+            bounds["max_depth"] = int(max_depth)
+        if max_nodes is not None:
+            bounds["max_nodes"] = int(max_nodes)
+        matches = window.find_all(**criteria, **bounds)
         if not matches:
-            return f"no element matching {criteria}"
+            return self._no_match(window, criteria, bounds)
         lines = [f"{len(matches)} match(es):"]
         for node in matches[:int(limit)]:
             lines.append(f"  {node!r} value={node.value!r} rect={node.rect}")
         if len(matches) > int(limit):
             lines.append(f"  ... and {len(matches) - int(limit)} more")
         return "\n".join(lines)
+
+    def _no_match(self, window, criteria: dict, bounds: dict) -> str:
+        """Whether "no match" means "not there" or "not within the bounds".
+
+        Issue #68: a control nested past the depth bound read as absent - "no
+        element matching" is what a genuinely missing element says too, and
+        nothing distinguished them. So an empty result walks the tree once
+        more, at the same bounds the search used, to ask the one question the
+        search result cannot answer: did the walk see the whole window? One
+        extra walk, spent only on the path where the caller was otherwise
+        about to trust a false "not there".
+        """
+        head = f"no element matching {criteria}"
+        nodes = list(window.reread(**bounds).walk())
+        if not any(node.truncated for node in nodes):
+            return head
+        max_depth = bounds.get("max_depth", uitree.DEFAULT_MAX_DEPTH)
+        max_nodes = bounds.get("max_nodes", uitree.DEFAULT_MAX_NODES)
+        return (f"{head} within max_depth={max_depth}/max_nodes={max_nodes} - "
+                f"but the search did not see the whole window: "
+                f"{_truncation_shape(nodes, max_depth, max_nodes)}. Raise the "
+                f"bound that cut before concluding the element is not there.")
 
     def read_text(self, app=None, title=None, **criteria) -> str:
         criteria = {k: v for k, v in criteria.items() if v is not None}
@@ -607,7 +679,8 @@ class ToolRegistry:
         threading.Thread(target=body, name=f"mcp-{name}", daemon=True).start()
         return (f"{name} started. Call get_action_result to see what it did.")
 
-    def get_action_result(self, name: str, wait: int = 30) -> str:
+    def get_action_result(self, name: str, wait: int = 30,
+                          level: str = "INFO", tail=None) -> str:
         # No name resolution first: the run record is the whole answer, and a
         # class that has been listed but never started should read as "not run"
         # rather than as an unknown name. It also keeps a result readable after
@@ -616,7 +689,12 @@ class ToolRegistry:
         if run is None:
             return (f"{name} has not been run since Keyhac started. "
                     f"start_action runs it.")
-        return run.report()
+        # INFO by default (issue #71): an action typing its way through a form
+        # leaves thousands of keymap DEBUG lines around the two INFO lines
+        # that carry the result, and the model reading this pays for all of
+        # them. The cut announces itself, so the DEBUG stream is one call away.
+        return run.report(level=level,
+                          tail=int(tail) if tail is not None else None)
 
     def cancel_action(self, name: str) -> str:
         action = self._action(name)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -31,14 +31,16 @@ from keyhac.mcp.tools import ToolRegistry
 
 
 class FakeNode:
-    def __init__(self, name="Main", children=()):
+    def __init__(self, name="Main", children=(), depth=0):
         self.name = name
         self.role = "AXWindow"
         self.value = None
         self.identifier = None
         self.rect = (0, 0, 100, 100)
+        self.depth = depth
         self.truncated = False
         self.children = list(children)
+        self.searched = None             # what find_all was last asked
 
     def walk(self):
         yield self
@@ -52,6 +54,7 @@ class FakeNode:
         return f"{self.role} {self.name!r}"
 
     def find_all(self, **criteria):
+        self.searched = criteria
         return [self]
 
     def find(self, **criteria):
@@ -341,6 +344,43 @@ def test_a_missing_window_says_what_to_do_next(registry):
 def test_find_elements_requires_a_criterion(registry):
     with pytest.raises(ValueError, match="at least one"):
         registry.call("find_elements", {})
+
+
+def test_find_elements_passes_the_walk_bounds_through(registry):
+    """Issue #68: controls in web content sit 30+ levels down, and the tool
+    offered no way to reach past the default depth - find_all had the
+    parameters all along."""
+    registry.call("find_elements",
+                  {"role": "PopUpButton", "max_depth": 45, "max_nodes": 6000})
+    assert registry.keymap.node.searched == {
+        "role": "PopUpButton", "max_depth": 45, "max_nodes": 6000}
+
+
+def test_the_bounds_alone_are_not_a_criterion(registry):
+    with pytest.raises(ValueError, match="at least one"):
+        registry.call("find_elements", {"max_depth": 45})
+
+
+def test_a_no_match_on_a_cut_walk_says_so(registry):
+    """Issue #68, the silent trap: "no element matching" read as "the control
+    is not there" when it meant "not within the default depth"."""
+    root = registry.keymap.node
+    root.find_all = lambda **criteria: []
+    root.truncated = True
+    text = registry.call("find_elements", {"role": "PopUpButton"})
+    assert "no element matching" in text
+    assert "did not see the whole window" in text
+    assert "max_depth=14" in text, "the bound it searched within, by name"
+
+
+def test_a_no_match_on_a_complete_walk_stays_plain(registry):
+    """When the walk really saw everything, "not there" is the whole truth and
+    a truncation warning would send the caller chasing bounds for nothing."""
+    root = registry.keymap.node
+    root.find_all = lambda **criteria: []
+    text = registry.call("find_elements", {"role": "PopUpButton"})
+    assert "no element matching" in text
+    assert "whole window" not in text
 
 
 def test_an_action_reports_what_it_logged(writable):
@@ -1645,7 +1685,7 @@ def test_a_hollow_web_area_points_at_content_access(registry):
     text = registry.call("describe_screen", {})
     assert "enable_content_access" in text
     assert "Raising max_nodes will not help" in text
-    assert "raise max_nodes/max_depth" not in text, "the misleading advice won"
+    assert "[truncated:" not in text, "the misleading advice won"
 
 
 def test_a_populated_web_area_does_not(registry):
@@ -1667,8 +1707,29 @@ def test_a_native_window_keeps_the_truncation_note(registry):
     root.children = [FakeNode(f"child{i}") for i in range(EMPTY_WINDOW + 5)]
     root.truncated = True
     text = registry.call("describe_screen", {})
-    assert "raise max_nodes/max_depth" in text
+    assert "[truncated:" in text
     assert "enable_content_access" not in text
+
+
+def test_the_truncation_note_reports_the_shape_of_the_cut(registry):
+    """Issue #54: "raise max_nodes/max_depth" without saying from what left
+    the next value a guess, and a measured session guessed twice. The walker
+    knew the numbers all along."""
+    from keyhac.mcp.tools import EMPTY_WINDOW
+
+    root = registry.keymap.node
+    root.children = [FakeNode(f"child{i}", depth=1)
+                     for i in range(EMPTY_WINDOW + 5)]
+    root.children[0].truncated = True     # a budget cut, shallow
+    root.children[0].depth = 3
+    root.children[1].truncated = True     # a depth cut, at the bound
+    root.children[1].depth = 14
+    text = registry.call("describe_screen", {})
+    assert f"reported {EMPTY_WINDOW + 6} node(s)" in text
+    assert "cut off at 2 point(s)" in text
+    assert "1 by max_depth=14" in text
+    assert "1 by the max_nodes=400 budget" in text
+    assert "deepest level reached: 14" in text
 
 
 # -- what an action hands back ----------------------------------------------
@@ -1801,6 +1862,58 @@ def test_a_long_run_is_bounded_and_says_it_was_truncated(writable):
     assert len(output) < MAX_CAPTURE * 1.5
     assert "characters dropped" in output
     assert "THE LAST LINE" in output, "the tail is where the failure is"
+
+
+def _noisy_run(name):
+    """A finished run whose output is the shape issue #71 measured: the two
+    INFO lines that carry the result, buried in keymap DEBUG keystrokes."""
+    run = capture.start_run(name)
+    for index in range(50):
+        run.output.write(f"DEBUG [keyhac.Keymap] D-Return {index}\n")
+        run.output.write(f"DEBUG [keyhac.Keymap] PASSTHRU : U-Return {index}\n")
+    run.output.write("INFO [keyhac.Probe] OK: 63 AZ x 2 row -> 126 rows\n")
+    run.output.write("printed: DONE\n")
+    run.finish("finished")
+    return run
+
+
+def test_the_keystroke_stream_is_hidden_by_default(registry):
+    """Issue #71: thousands of keymap DEBUG lines buried the INFO lines that
+    carried the result. INFO is the default, and the cut announces itself."""
+    _noisy_run("noisy.Filtered")
+    out = registry.call("get_action_result",
+                        {"name": "noisy.Filtered", "wait": 0})
+    assert "PASSTHRU" not in out
+    assert "OK: 63 AZ x 2 row -> 126 rows" in out
+    assert "printed: DONE" in out, "print() is not a log line to filter"
+    assert "100 log line(s) below INFO hidden" in out
+
+
+def test_the_keystroke_stream_is_one_call_away(registry):
+    _noisy_run("noisy.Filtered")
+    out = registry.call("get_action_result",
+                        {"name": "noisy.Filtered", "wait": 0,
+                         "level": "DEBUG"})
+    assert "PASSTHRU : U-Return 49" in out
+    assert "hidden" not in out
+
+
+def test_tail_keeps_the_end_and_says_what_it_dropped(registry):
+    _noisy_run("noisy.Tailed")
+    out = registry.call("get_action_result",
+                        {"name": "noisy.Tailed", "wait": 0,
+                         "level": "DEBUG", "tail": 2})
+    assert "showing the last 2 of 102 lines" in out
+    assert "OK: 63" in out and "printed: DONE" in out
+    assert "PASSTHRU" not in out, "the middle of the progress bar is gone"
+
+
+def test_a_wrong_level_is_told_its_choices(registry):
+    _noisy_run("noisy.Filtered")
+    with pytest.raises(ValueError, match="DEBUG, INFO, WARNING"):
+        registry.call("get_action_result",
+                      {"name": "noisy.Filtered", "wait": 0,
+                       "level": "VERBOSE"})
 
 
 # -- the asynchronous shape --------------------------------------------------


### PR DESCRIPTION
Three small MCP tool improvements, each one round trip saved per occurrence:

- **`describe_screen` reports the shape of what it truncated** (closes #54). The note now says how many nodes were reported, how many points the walk was cut at - split by whether `max_depth` or the `max_nodes` budget did the cutting - and the deepest level reached, so the next call can be sized instead of guessed.
- **`find_elements` takes `max_depth` / `max_nodes`** (closes #68), for parity with `find_all`, and a no-match reply on a truncated walk now says the search did not see the whole window (with the same cut-shape report) instead of a bare "no element matching" that reads as "the control is not there".
- **`get_action_result` takes `level` (default INFO) and `tail`** (closes #71), so the per-keystroke keymap DEBUG stream no longer buries the INFO lines that carry the result. Both cuts announce themselves in the output, with the way to get the full stream back.

All filtering happens at read time - nothing is dropped from the capture, so asking again with `level="DEBUG"` still returns everything.

Tests: 518 passed, 17 skipped; `make api-reference-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)