### PR TITLE
find_elements: keep the search bounds, revert the no-match second walk

### DIFF
--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -229,8 +229,11 @@ class ToolRegistry:
                      "max_depth": {**integer, "description": "How deep to "
                                    f"search (default {uitree.DEFAULT_MAX_DEPTH}"
                                    "). Web content can nest controls 30+ "
-                                   "levels down; a no-match reply says when "
-                                   "this bound cut the search short."},
+                                   "levels down, and a search cut short by "
+                                   "this bound reports the same 'no element "
+                                   "matching' as a genuinely absent element - "
+                                   "raise it before concluding one is not "
+                                   "there."},
                      "max_nodes": {**integer, "description": "Node budget for "
                                    "the search (default "
                                    f"{uitree.DEFAULT_MAX_NODES})."}}},
@@ -523,35 +526,20 @@ class ToolRegistry:
             bounds["max_nodes"] = int(max_nodes)
         matches = window.find_all(**criteria, **bounds)
         if not matches:
-            return self._no_match(window, criteria, bounds)
+            # Deliberately plain. This cannot tell "absent" from "not within
+            # the bounds" - the walked tree and its truncation marks die
+            # inside find_all, and the runtime diagnostic that re-walked the
+            # tree here to recover them was reverted: a second live walk,
+            # describing a second snapshot the search never saw. The
+            # ambiguity is accepted and taught in the max_depth description
+            # instead; issue #76 holds the candidate real fix.
+            return f"no element matching {criteria}"
         lines = [f"{len(matches)} match(es):"]
         for node in matches[:int(limit)]:
             lines.append(f"  {node!r} value={node.value!r} rect={node.rect}")
         if len(matches) > int(limit):
             lines.append(f"  ... and {len(matches) - int(limit)} more")
         return "\n".join(lines)
-
-    def _no_match(self, window, criteria: dict, bounds: dict) -> str:
-        """Whether "no match" means "not there" or "not within the bounds".
-
-        Issue #68: a control nested past the depth bound read as absent - "no
-        element matching" is what a genuinely missing element says too, and
-        nothing distinguished them. So an empty result walks the tree once
-        more, at the same bounds the search used, to ask the one question the
-        search result cannot answer: did the walk see the whole window? One
-        extra walk, spent only on the path where the caller was otherwise
-        about to trust a false "not there".
-        """
-        head = f"no element matching {criteria}"
-        nodes = list(window.reread(**bounds).walk())
-        if not any(node.truncated for node in nodes):
-            return head
-        max_depth = bounds.get("max_depth", uitree.DEFAULT_MAX_DEPTH)
-        max_nodes = bounds.get("max_nodes", uitree.DEFAULT_MAX_NODES)
-        return (f"{head} within max_depth={max_depth}/max_nodes={max_nodes} - "
-                f"but the search did not see the whole window: "
-                f"{_truncation_shape(nodes, max_depth, max_nodes)}. Raise the "
-                f"bound that cut before concluding the element is not there.")
 
     def read_text(self, app=None, title=None, **criteria) -> str:
         criteria = {k: v for k, v in criteria.items() if v is not None}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -361,26 +361,22 @@ def test_the_bounds_alone_are_not_a_criterion(registry):
         registry.call("find_elements", {"max_depth": 45})
 
 
-def test_a_no_match_on_a_cut_walk_says_so(registry):
-    """Issue #68, the silent trap: "no element matching" read as "the control
-    is not there" when it meant "not within the default depth"."""
+def test_a_no_match_stays_plain_even_when_the_walk_was_cut(registry):
+    """Deliberate (#68 second thoughts, issue #76): the runtime diagnostic
+    that re-walked the tree on an empty result - to say whether "no match"
+    meant "absent" or "not within the bounds" - was reverted. It cost a
+    second live accessibility walk, and it described a second snapshot the
+    search never saw. The ambiguity is accepted for now: taught statically
+    in the max_depth schema description, with the candidate real fix (a
+    stats out-parameter on find_all) recorded in the issue."""
     root = registry.keymap.node
     root.find_all = lambda **criteria: []
     root.truncated = True
+    reread = []
+    root.reread = lambda **kw: reread.append(kw) or root
     text = registry.call("find_elements", {"role": "PopUpButton"})
-    assert "no element matching" in text
-    assert "did not see the whole window" in text
-    assert "max_depth=14" in text, "the bound it searched within, by name"
-
-
-def test_a_no_match_on_a_complete_walk_stays_plain(registry):
-    """When the walk really saw everything, "not there" is the whole truth and
-    a truncation warning would send the caller chasing bounds for nothing."""
-    root = registry.keymap.node
-    root.find_all = lambda **criteria: []
-    text = registry.call("find_elements", {"role": "PopUpButton"})
-    assert "no element matching" in text
-    assert "whole window" not in text
+    assert text == "no element matching {'role': 'PopUpButton'}"
+    assert reread == [], "and no second walk happened to say more"
 
 
 def test_an_action_reports_what_it_logged(writable):


### PR DESCRIPTION
Follow-up to #75, partially reverting its #68 half after design discussion:

- **Kept**: `max_depth` / `max_nodes` on `find_elements` — the indispensable half; without it an agent cannot reach controls nested past the default depth at all.
- **Reverted**: the `_no_match` diagnostic that re-walked the tree on an empty result to report truncation. It cost a second live accessibility walk on every no-match, and the second walk describes a second snapshot — not necessarily the tree that was searched.
- The "no match may mean not-within-bounds" lesson moves into the `max_depth` schema description, where it costs nothing at runtime; `test_a_no_match_stays_plain_even_when_the_walk_was_cut` pins the decision and points at the rationale.
- #76 records the accepted limitation and the candidate future fix (an additive stats out-parameter on `find_all`, to be taken up when a second consumer justifies the public-API commitment).

`describe_screen`'s truncation-shape report (#54) is untouched: there the walked tree is the tool's own return value, so the numbers are free and describe the actual tree.

Tests: 517 passed, 17 skipped; `make api-reference-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)