### PR TITLE
Breaking-change ideas now have somewhere to wait

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,10 @@ Documentation:
   [design-notes](doc/dev/design-notes.md), [puikit](doc/dev/puikit.md),
   [packaging](doc/dev/packaging.md), [testing](doc/dev/testing.md).
 - Remaining tasks and open decisions live in the **GitHub issues**
-  (`gh issue list`), not in the docs.
+  (`gh issue list`), not in the docs. One exception:
+  [doc/dev/next-major.md](doc/dev/next-major.md) is the ledger of breaking API
+  changes the additive-only policy defers to the next major release — record
+  such ideas there, not as issues.
 
 ## Sibling repositories (read-only references)
 

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -15,6 +15,8 @@ people working on Keyhac itself.
 - [packaging.md](packaging.md) — launchers, bundles, release pipeline, data paths.
 - [testing.md](testing.md) — test layers, harness patterns, live verification
   record.
+- [next-major.md](next-major.md) — ledger of breaking API changes deferred to
+  the next major release by the additive-only policy, with reasoning.
 - [ai-integration.md](ai-integration.md) — the AI integration design: agent at
   authoring time producing plain-Python actions, the UI-mediated ETL workload
   they target, the five layers, the output-side primitives, MCP topologies,

--- a/doc/dev/next-major.md
+++ b/doc/dev/next-major.md
@@ -1,0 +1,43 @@
+# Next major release — deferred breaking changes
+
+A ledger of API changes that are worth making but cannot be made now: the public
+surface (config API, MCP tools, `UINode`) is additive-only within 2.x, so a
+change that renames, removes or reshapes anything waits for 3.0. This is the
+place to write such an idea down at the moment it is noticed, with the reasoning
+attached, so the next major release starts from a reasoned list instead of a
+memory.
+
+Relationship to the GitHub issues: an issue tracks work that can be done now;
+an entry here is blocked by the compatibility policy itself, not by effort or
+priority. When a major release is actually planned, entries graduate into
+issues.
+
+Each entry records: what changes, why the current shape is wrong, why it must
+wait, and what the migration looks like.
+
+## Rename MCP tool `describe_screen` → `describe_window`
+
+**What.** Rename the MCP tool. No behavior change.
+
+**Why.** The name says "screen"; the contract is one window: it resolves a
+single window via `app=`/`title=` (focused window by default) and dumps that
+window's element tree. Its own description and the tool table in
+[ai-integration.md](../ai-integration.md) both say "a window's element tree".
+`describe_window` states the contract and pairs naturally with `list_windows`.
+
+**Why it waits.** The tool is released public surface. A clean rename breaks
+both bundled skills, the docs, the tests, and any user-side prompts or notes
+that name the tool. The additive alternative — shipping `describe_window` as an
+alias — costs a permanent extra entry in every session's tool list (context
+tokens on every request) and a which-one-do-I-call ambiguity, which is worse
+than the misnomer. Mitigating the wait: in MCP the description travels with the
+name, so callers see "Read a window's element tree" on every call — the
+imprecision does not mislead in practice — and the old name does match the
+authoring vocabulary ("read the screen before you write") used throughout the
+docs and skills.
+
+**Migration.** Rename in `keyhac/mcp/tools.py`; update both skills,
+[ai-integration.md](../ai-integration.md) (§tool table, log examples) and
+`tests/test_mcp.py` in the same commit. Keep the authoring-workflow prose
+("open the screen the action will work against") — it describes operator
+intent, not the tool name.


### PR DESCRIPTION
doc/dev/next-major.md is a ledger for API changes the additive-only policy defers to the next major release, so they are written down with their reasoning when noticed instead of remembered at planning time. Each entry records what changes, why the current shape is wrong, why it must wait, and what the migration looks like.

Seeded with the first entry: renaming the MCP tool `describe_screen` to `describe_window` (it reads one window, not the screen), including why a 2.x alias was rejected. The doc is registered in the dev-doc index, and CLAUDE.md's decisions-live-in-issues rule now names this ledger as its one exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)