### PR TITLE
Six docstrings said Claude where they meant any agent

### DIFF
--- a/doc/action-api.md
+++ b/doc/action-api.md
@@ -246,7 +246,7 @@ Note `is not None`, not truthiness: an unchecked checkbox's value is 0 and an em
 dump(max_value: 'int' = 60) → str
 ```
 
-This subtree as indented text - to read, and to hand to Claude. 
+This subtree as indented text - to read, and to hand to an AI agent. 
 
 ---
 

--- a/keyhac/core/uitree.py
+++ b/keyhac/core/uitree.py
@@ -195,7 +195,7 @@ class UINode:
             prune=prune))
 
     def dump(self, max_value: int = 60) -> str:
-        """This subtree as indented text - to read, and to hand to Claude."""
+        """This subtree as indented text - to read, and to hand to an AI agent."""
         return format_tree(self, max_value=max_value)
 
     # -- the text layer ------------------------------------------------------
@@ -421,7 +421,7 @@ def find_element(root, **kwargs) -> UINode | None:
 
 
 def format_tree(node: UINode, indent: int = 0, max_value: int = 60) -> str:
-    """The tree as indented text - for reading, and for handing to Claude.
+    """The tree as indented text - for reading, and for handing to an AI agent.
 
     Deliberately terse: this is what gets pasted into a conversation while an
     action is being written, and a page's worth of it has to stay readable.

--- a/keyhac/mcp/__init__.py
+++ b/keyhac/mcp/__init__.py
@@ -1,4 +1,4 @@
-"""Keyhac's MCP endpoint: the tools Claude uses to author actions.
+"""Keyhac's MCP endpoint: the tools an AI agent uses to author actions.
 
 `server.py` serves them over localhost HTTP from inside the daemon, `tools.py`
 defines them, and `bridge.py` is the stdio shim for clients that spawn a

--- a/keyhac/mcp/server.py
+++ b/keyhac/mcp/server.py
@@ -1,6 +1,6 @@
 """The MCP endpoint Keyhac serves on localhost.
 
-Claude reaches Keyhac's tools through this: it inspects the screen an action
+The agent reaches Keyhac's tools through this: it inspects the screen an action
 will run against, runs the action, reads what went wrong, and tries again.
 That loop - and not runtime inference - is the whole of the AI integration
 (doc/dev/ai-integration.md §3.1).

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -1,4 +1,4 @@
-"""The tools Claude gets, and why these ones.
+"""The tools the agent gets, and why these ones.
 
 They follow the escalation ladder in doc/dev/ai-integration.md §8.1: read the
 screen that is already on it, ask the operator to open the state that is not,
@@ -138,7 +138,7 @@ def _running_action(name: str):
 
 
 class Tool:
-    """One callable, its JSON Schema, and the description Claude reads."""
+    """One callable, its JSON Schema, and the description the agent reads."""
 
     def __init__(self, name, description, schema, run):
         self.name = name


### PR DESCRIPTION
ai-integration.md is explicit that the integration is client-agnostic ("The *content* is not Claude-specific"; VS Code Copilot verified), but six docstrings still used Claude as a stand-in for whatever agent is on the other end — one of them user-facing, flowing into the generated action-api.md (`UINode.dump`). They now say "the agent" / "an AI agent"; `make api-reference` regenerated the doc in the same commit.

Product references are deliberately untouched: bridge.py's Claude Desktop process model and registration snippet, Claude in the Electron app example list, and the measured element count of the Claude app's web area in tools.py.

Tests: 516 passed, 17 skipped; the one failure (`test_mac_mouse.py::TestLive::test_relative_move_is_exact_and_cursor_pos_agrees`) is a live cursor-movement test sensitive to the machine being in use — this change is comments and docstrings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)