### PR TITLE
find, find_all and the waits take the walk bounds

### DIFF
--- a/doc/action-api.md
+++ b/doc/action-api.md
@@ -260,24 +260,48 @@ Prints the snapshot as held: a node from `ui.window()` or `ui.node()` has read n
 ### <kbd>method</kbd> `UINode.find`
 
 ```python
-find(**criteria) → 'UINode | None'
+find(
+    max_depth: 'int' = 14,
+    max_nodes: 'int' = 1000,
+    **criteria
+) → 'UINode | None'
 ```
 
 The first element below this one matching `criteria`, or None. 
 
-Reads the live UI at call time - this node's captured `children` play no part, so an old window node finds what is on screen *now*. Criteria are `role`, `name`, `value`, `identifier`, `text` and `predicate`; patterns are case-insensitive fnmatch with "|" alternation.  None rather than an exception, because only the caller knows whether a missing element is a failed precondition or an expected absence - `wait_for` is the one that insists. 
+Reads the live UI at call time - this node's captured `children` play no part, so an old window node finds what is on screen *now*. None rather than an exception, because only the caller knows whether a missing element is a failed precondition or an expected absence - `wait_for` is the one that insists. 
+
+
+
+**Args:**
+ 
+ - <b>`max_depth`</b>:  Depth bound for the underlying walk.  Web content can  nest controls deeper than the default; raise this before  concluding an element is not there. 
+ - <b>`max_nodes`</b>:  Node budget for the underlying walk. 
+ - <b>`**criteria`</b>:  `role`, `name`, `value`, `identifier`, `text` and  `predicate`; patterns are case-insensitive fnmatch with "|"  alternation. 
 
 ---
 
 ### <kbd>method</kbd> `UINode.find_all`
 
 ```python
-find_all(**criteria) → list['UINode']
+find_all(
+    max_depth: 'int' = 14,
+    max_nodes: 'int' = 1000,
+    **criteria
+) → list['UINode']
 ```
 
 Every element below this one matching `criteria`, in tree order. 
 
 The same live read as `find` - the snapshot is not consulted. 
+
+
+
+**Args:**
+ 
+ - <b>`max_depth`</b>:  Depth bound for the underlying walk. 
+ - <b>`max_nodes`</b>:  Node budget for the underlying walk. 
+ - <b>`**criteria`</b>:  As `find`. 
 
 ---
 
@@ -378,11 +402,23 @@ Returns the mechanism that worked; raises `FillFailed` when none did. Takes the 
 wait_for(
     timeout: 'float' = 10.0,
     message: 'str | None' = None,
+    max_depth: 'int' = 14,
+    max_nodes: 'int' = 1000,
     **criteria
 ) → 'UINode'
 ```
 
 Wait until an element matching `criteria` exists below this one. 
+
+
+
+**Args:**
+ 
+ - <b>`timeout`</b>:  Seconds before giving up. 
+ - <b>`message`</b>:  What was being waited for, for the timeout error. 
+ - <b>`max_depth`</b>:  Depth bound for the walk.  Every poll walks the tree  again, so this is a cost bound as much as a reach bound. 
+ - <b>`max_nodes`</b>:  Node budget for the walk. 
+ - <b>`**criteria`</b>:  As `find`. 
 
 ---
 
@@ -392,11 +428,25 @@ Wait until an element matching `criteria` exists below this one.
 wait_until_gone(
     timeout: 'float' = 10.0,
     message: 'str | None' = None,
+    max_depth: 'int' = 14,
+    max_nodes: 'int' = 1000,
     **criteria
 ) → None
 ```
 
 Wait until nothing below this one matches `criteria`. 
+
+A bound makes "gone" mean "not found within the bounds": an element deeper than `max_depth` counts as gone. 
+
+
+
+**Args:**
+ 
+ - <b>`timeout`</b>:  Seconds before giving up. 
+ - <b>`message`</b>:  What was being waited for, for the timeout error. 
+ - <b>`max_depth`</b>:  Depth bound for the walk. 
+ - <b>`max_nodes`</b>:  Node budget for the walk. 
+ - <b>`**criteria`</b>:  As `find`. 
 
 ---
 

--- a/keyhac/core/uitree.py
+++ b/keyhac/core/uitree.py
@@ -171,27 +171,44 @@ class UINode:
     # call site remember that produced a wrapper around nearly every line of
     # the first six actions written against this API.
 
-    def find(self, **criteria) -> "UINode | None":
+    def find(self, max_depth: int = DEFAULT_MAX_DEPTH,
+             max_nodes: int = DEFAULT_MAX_NODES, **criteria) -> "UINode | None":
         """The first element below this one matching `criteria`, or None.
 
         Reads the live UI at call time - this node's captured `children`
         play no part, so an old window node finds what is on screen *now*.
-        Criteria are `role`, `name`, `value`, `identifier`, `text` and
-        `predicate`; patterns are case-insensitive fnmatch with "|"
-        alternation.  None rather than an exception, because only the caller
-        knows whether a missing element is a failed precondition or an
-        expected absence - `wait_for` is the one that insists.
+        None rather than an exception, because only the caller knows whether
+        a missing element is a failed precondition or an expected absence -
+        `wait_for` is the one that insists.
+
+        Args:
+            max_depth: Depth bound for the underlying walk.  Web content can
+                nest controls deeper than the default; raise this before
+                concluding an element is not there.
+            max_nodes: Node budget for the underlying walk.
+            **criteria: `role`, `name`, `value`, `identifier`, `text` and
+                `predicate`; patterns are case-insensitive fnmatch with "|"
+                alternation.
         """
         from keyhac.core.wait import evaluate_on_main_thread
-        return evaluate_on_main_thread(lambda: find_element(self, **criteria))
+        return evaluate_on_main_thread(lambda: find_element(
+            self, max_depth=max_depth, max_nodes=max_nodes, **criteria))
 
-    def find_all(self, **criteria) -> list["UINode"]:
+    def find_all(self, max_depth: int = DEFAULT_MAX_DEPTH,
+                 max_nodes: int = DEFAULT_MAX_NODES,
+                 **criteria) -> list["UINode"]:
         """Every element below this one matching `criteria`, in tree order.
 
         The same live read as `find` - the snapshot is not consulted.
+
+        Args:
+            max_depth: Depth bound for the underlying walk.
+            max_nodes: Node budget for the underlying walk.
+            **criteria: As `find`.
         """
         from keyhac.core.wait import evaluate_on_main_thread
-        return evaluate_on_main_thread(lambda: find_elements(self, **criteria))
+        return evaluate_on_main_thread(lambda: find_elements(
+            self, max_depth=max_depth, max_nodes=max_nodes, **criteria))
 
     def reread(self, max_depth: int = DEFAULT_MAX_DEPTH,
                max_nodes: int = DEFAULT_MAX_NODES,
@@ -261,17 +278,43 @@ class UINode:
     # -- waiting, scoped to this subtree -------------------------------------
 
     def wait_for(self, timeout: float = 10.0, message: str | None = None,
-                 **criteria) -> "UINode":
-        """Wait until an element matching `criteria` exists below this one."""
+                 max_depth: int = DEFAULT_MAX_DEPTH,
+                 max_nodes: int = DEFAULT_MAX_NODES, **criteria) -> "UINode":
+        """Wait until an element matching `criteria` exists below this one.
+
+        Args:
+            timeout: Seconds before giving up.
+            message: What was being waited for, for the timeout error.
+            max_depth: Depth bound for the walk.  Every poll walks the tree
+                again, so this is a cost bound as much as a reach bound.
+            max_nodes: Node budget for the walk.
+            **criteria: As `find`.
+        """
         from keyhac.core.wait import wait_for_element
         return wait_for_element(self, timeout=timeout, message=message,
+                                max_depth=max_depth, max_nodes=max_nodes,
                                 **criteria)
 
     def wait_until_gone(self, timeout: float = 10.0,
-                        message: str | None = None, **criteria) -> None:
-        """Wait until nothing below this one matches `criteria`."""
+                        message: str | None = None,
+                        max_depth: int = DEFAULT_MAX_DEPTH,
+                        max_nodes: int = DEFAULT_MAX_NODES,
+                        **criteria) -> None:
+        """Wait until nothing below this one matches `criteria`.
+
+        A bound makes "gone" mean "not found within the bounds": an element
+        deeper than `max_depth` counts as gone.
+
+        Args:
+            timeout: Seconds before giving up.
+            message: What was being waited for, for the timeout error.
+            max_depth: Depth bound for the walk.
+            max_nodes: Node budget for the walk.
+            **criteria: As `find`.
+        """
         from keyhac.core.wait import wait_until_gone
-        wait_until_gone(self, timeout=timeout, message=message, **criteria)
+        wait_until_gone(self, timeout=timeout, message=message,
+                        max_depth=max_depth, max_nodes=max_nodes, **criteria)
 
     def wait_until_stable(self, quiet: float = 0.3, timeout: float = 10.0,
                           **bounds) -> None:

--- a/keyhac/core/wait.py
+++ b/keyhac/core/wait.py
@@ -206,7 +206,9 @@ def wait_for(condition: Callable[[], Any],
 
 
 def wait_for_element(root, timeout: float = DEFAULT_TIMEOUT,
-                     message: str | None = None, **criteria) -> UINode:
+                     message: str | None = None,
+                     max_depth: int | None = None,
+                     max_nodes: int | None = None, **criteria) -> UINode:
     """Wait until an element matching `criteria` exists, and return it.
 
     The first beat of the three that every menu and modal needs: wait for it to
@@ -219,29 +221,48 @@ def wait_for_element(root, timeout: float = DEFAULT_TIMEOUT,
         message: What was being waited for, for the timeout error.  Defaults to
             the criteria, which names the element but not the step - say what
             the step was when an operator will read it.
+        max_depth: Depth bound for each read.  Every poll walks the tree
+            again, so this is a cost bound as much as a reach bound.
+        max_nodes: Node bound for each read.
         **criteria: As `find_element` - role, name, value, identifier, text,
             predicate.
 
     Raises:
         WaitTimeout: Nothing matched in time.
     """
+    bounds = {}
+    if max_depth is not None:
+        bounds["max_depth"] = max_depth
+    if max_nodes is not None:
+        bounds["max_nodes"] = max_nodes
     described = ", ".join(f"{k}={v!r}" for k, v in criteria.items())
-    return wait_for(lambda: find_element(root, **criteria), timeout=timeout,
+    return wait_for(lambda: find_element(root, **bounds, **criteria),
+                    timeout=timeout,
                     message=message or f"an element matching {described}")
 
 
 def wait_until_gone(root, timeout: float = DEFAULT_TIMEOUT,
-                    message: str | None = None, **criteria) -> None:
+                    message: str | None = None,
+                    max_depth: int | None = None,
+                    max_nodes: int | None = None, **criteria) -> None:
     """Wait until no element matches `criteria`.
 
     The third beat, and the one that actually breaks iteration when it is left
     out: without it the next cycle starts while the previous modal is still on
     screen, and clicks land in it.
 
-    Takes the same arguments as `wait_for_element`.
+    Takes the same arguments as `wait_for_element`.  A bound makes "gone" mean
+    "not found within the bounds": an element deeper than `max_depth` counts
+    as gone.
     """
+    bounds = {}
+    if max_depth is not None:
+        bounds["max_depth"] = max_depth
+    if max_nodes is not None:
+        bounds["max_nodes"] = max_nodes
     described = ", ".join(f"{k}={v!r}" for k, v in criteria.items())
-    wait_for(lambda: find_element(root, **criteria) is None, timeout=timeout,
+    wait_for(lambda: find_element(root, **bounds, **criteria) is None,
+             timeout=timeout,
              message=message or f"no element matching {described}")
 
 

--- a/keyhac/skills/keyhac-action-authoring/references/practice.md
+++ b/keyhac/skills/keyhac-action-authoring/references/practice.md
@@ -48,9 +48,10 @@ for node in tree.walk(): ...
 ```
 
 **Criteria** — `role`, `name`, `value`, `identifier`, `text`, `predicate`, plus
-`max_depth` / `max_nodes` on `find_all` and `reread`. Role patterns accept the
-macOS names with or without the `AX` prefix, but the prefix is stripped from
-the *role*, not the pattern: `role="AXTable"` matches nothing on Windows.
+`max_depth` / `max_nodes` on `find`, `find_all`, `reread` and the waits. Role
+patterns accept the macOS names with or without the `AX` prefix, but the prefix
+is stripped from the *role*, not the pattern: `role="AXTable"` matches nothing
+on Windows.
 
 **A node is a snapshot.** `find`/`find_all` read the live UI each time; the
 node they return does not update. Re-`find` after the screen changes.

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -12,6 +12,7 @@ import threading
 import pytest
 
 from keyhac.core.uitree import UINode
+from keyhac.core.wait import WaitTimeout
 
 
 class FakeElement:
@@ -234,6 +235,35 @@ def test_find_and_find_all(ui):
     assert window.find(identifier="save").name == "Save"
     assert window.find(identifier="nope") is None
     assert len(window.find_all(role="AXButton|AXCheckBox")) == 2
+
+
+def test_find_takes_the_walk_bounds(ui):
+    api, element = ui
+    element.kids.append(FakeElement("AXGroup", key="g1", children=[
+        FakeElement("AXGroup", key="g2", children=[
+            FakeElement("AXButton", identifier="deep", key="d")])]))
+    window = api.window(app="TestApp")
+    assert window.find(identifier="deep", max_depth=1) is None
+    assert window.find(identifier="deep", max_depth=5).identifier == "deep"
+
+
+def test_find_all_takes_the_walk_bounds(ui):
+    api, _element = ui
+    window = api.window(app="TestApp")
+    everything = window.find_all(role="*")
+    cut = window.find_all(role="*", max_nodes=2)
+    assert 0 < len(cut) < len(everything)
+
+
+def test_wait_for_takes_the_walk_bounds(ui):
+    api, element = ui
+    element.kids.append(FakeElement("AXGroup", key="g", children=[
+        FakeElement("AXSheet", identifier="modal", key="m")]))
+    window = api.window(app="TestApp")
+    assert window.wait_for(identifier="modal", max_depth=5,
+                           timeout=1).role == "AXSheet"
+    with pytest.raises(WaitTimeout):
+        window.wait_for(identifier="modal", max_depth=1, timeout=0.2)
 
 
 def test_reread_gives_a_fresh_snapshot(ui):

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -138,6 +138,36 @@ def test_wait_until_gone():
     assert root.kids == []
 
 
+def test_wait_for_element_takes_the_walk_bounds():
+    button = Fake("AXButton", identifier="save", key="s")
+    group = Fake("AXGroup", key="g", children=[button])
+    root = Fake("Window", children=[group], key="w")
+    node = wait_for_element(root, identifier="save", max_depth=5, timeout=1)
+    assert node.identifier == "save"
+    with pytest.raises(WaitTimeout):
+        wait_for_element(root, identifier="save", max_depth=1, timeout=0.2)
+
+
+def test_the_walk_bounds_stay_out_of_the_timeout_message():
+    """The bounds are how far to look, not what was being looked for - an
+    operator reading the error needs the criteria, not the walk budget."""
+    root = Fake("Window", key="w")
+    with pytest.raises(WaitTimeout) as err:
+        wait_for_element(root, identifier="nope", max_depth=3, timeout=0.2)
+    assert "identifier='nope'" in str(err.value)
+    assert "max_depth" not in str(err.value)
+
+
+def test_wait_until_gone_within_bounds_counts_a_deep_element_gone():
+    """A bound makes "gone" mean "not found within the bounds"."""
+    modal = Fake("AXSheet", identifier="modal", key="m")
+    group = Fake("AXGroup", key="g", children=[modal])
+    root = Fake("Window", children=[group], key="w")
+    wait_until_gone(root, identifier="modal", max_depth=1, timeout=2)
+    with pytest.raises(WaitTimeout):
+        wait_until_gone(root, identifier="modal", timeout=0.2)
+
+
 def test_wait_until_gone_times_out_while_it_is_still_there():
     root = Fake("Window", children=[Fake("AXSheet", identifier="modal", key="m")],
                 key="w")


### PR DESCRIPTION
Fixes #57

`reread` already named `max_depth` / `max_nodes`; `find`, `find_all`, `wait_for` and `wait_until_gone` accepted them only accidentally, through `**criteria` forwarding into `uitree.find_elements` — undocumented, and on the waits the accident leaked the bounds into the operator-facing timeout message (`an element matching role='Row', max_depth=30`).

- The four `UINode` methods now name both parameters with the class's own defaults, mirroring `reread`, and forward explicitly. Docstrings document them (`doc/action-api.md` regenerated).
- `wait_for_element` / `wait_until_gone` in `keyhac/core/wait.py` take them as `int | None = None` (the `wait_for_stable` idiom) and keep them out of the `described` message — the one behavior change, pinned by `test_the_walk_bounds_stay_out_of_the_timeout_message`.
- On `wait_until_gone` a bound changes what "gone" means — *not found within the bounds*, so an element deeper than `max_depth` counts as gone. That can end a gone-wait early, so it is documented and pinned (`test_wait_until_gone_within_bounds_counts_a_deep_element_gone`) rather than discovered.
- `wait_until_gone` is included beyond the issue's three methods: identical shape, identical gap, same additive fix.
- practice.md's claim that the bounds exist "on `find_all` and `reread`" was ahead of the code (the issue's own note); it now reads "`find`, `find_all`, `reread` and the waits" and is true.

Note: the bounds are also a *cost* knob on the waits — every poll re-walks the tree — which the new docstrings say explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)