### PR TITLE
An AX-prefixed role pattern that matched nothing says why

### DIFF
--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -118,6 +118,25 @@ def _truncation_shape(nodes: list, max_depth: int, max_nodes: int) -> str:
             f"{max(node.depth for node in nodes)}")
 
 
+def _portable_role_spelling(pattern: str) -> str | None:
+    """The unprefixed spelling of an "AX"-prefixed role pattern, or None.
+
+    "AX" is macOS vocabulary: an AX-prefixed pattern matches only macOS
+    roles, while the unprefixed spelling matches the AX name there too, so
+    it is the portable one (issue #69).  Purely syntactic - this reads the
+    pattern, never the tree, so the no-match path stays a single walk
+    (issue #76).  A wildcard-led remainder ("AX*") is left alone: stripping
+    it would turn "every AX-prefixed role" into "everything".
+    """
+    branches = [b.strip() for b in pattern.split("|")]
+    stripped = [b[2:] if (b[:2].lower() == "ax" and len(b) > 2
+                          and b[2] not in "*?[") else b
+                for b in branches]
+    if stripped == branches:
+        return None
+    return "|".join(stripped)
+
+
 def _running_action(name: str):
     """A running action filed under `name`, whoever started it.
 
@@ -216,8 +235,10 @@ class ToolRegistry:
                  "selector you are about to write actually matches.",
                  {"type": "object", "properties": {
                      **window_args,
-                     "role": {**string, "description": "Role pattern. macOS "
-                              "names may drop the AX prefix."},
+                     "role": {**string, "description": "Role pattern. The AX "
+                              "prefix may be dropped in the pattern ('Row' "
+                              "matches AXRow); an AX-prefixed pattern matches "
+                              "only macOS roles."},
                      "name": {**string, "description": "Label pattern."},
                      "value": {**string, "description": "Content pattern."},
                      "identifier": {**string, "description":
@@ -533,7 +554,17 @@ class ToolRegistry:
             # describing a second snapshot the search never saw. The
             # ambiguity is accepted and taught in the max_depth description
             # instead; issue #76 holds the candidate real fix.
-            return f"no element matching {criteria}"
+            text = f"no element matching {criteria}"
+            role = criteria.get("role")
+            suggested = (_portable_role_spelling(role)
+                         if isinstance(role, str) else None)
+            if suggested:
+                text += (f'\n\n[an "AX"-prefixed role pattern only matches '
+                         f'macOS roles - the unprefixed spelling matches the '
+                         f'AX name too and is the portable one: try '
+                         f'role="{suggested}". On macOS, also raise max_depth '
+                         f'before concluding the element is not there]')
+            return text
         lines = [f"{len(matches)} match(es):"]
         for node in matches[:int(limit)]:
             lines.append(f"  {node!r} value={node.value!r} rect={node.rect}")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -379,6 +379,37 @@ def test_a_no_match_stays_plain_even_when_the_walk_was_cut(registry):
     assert reread == [], "and no second walk happened to say more"
 
 
+def test_an_ax_prefixed_no_match_names_the_portable_spelling(registry):
+    """Issue #69: "AX" is macOS vocabulary - an AX-prefixed pattern matches
+    only macOS roles, and rediscovering that cost a session several calls.
+    The hint is syntactic, read off the pattern alone, so the no-match path
+    stays a single walk (issue #76)."""
+    root = registry.keymap.node
+    root.find_all = lambda **criteria: []
+    reread = []
+    root.reread = lambda **kw: reread.append(kw) or root
+    text = registry.call("find_elements", {"role": "AXPopUpButton|Cell"})
+    assert text.startswith(
+        "no element matching {'role': 'AXPopUpButton|Cell'}")
+    assert 'role="PopUpButton|Cell"' in text
+    assert reread == [], "the hint is syntactic - no second walk"
+
+
+def test_a_wildcard_ax_pattern_gets_no_suggestion(registry):
+    """Stripping "AX*" would leave "*" - every role - so it is left alone
+    and the no-match reply stays plain."""
+    root = registry.keymap.node
+    root.find_all = lambda **criteria: []
+    text = registry.call("find_elements", {"role": "AX*"})
+    assert text == "no element matching {'role': 'AX*'}"
+
+
+def test_a_match_found_with_an_ax_pattern_gets_no_hint(registry):
+    """The spelling advice is for the no-match path only."""
+    text = registry.call("find_elements", {"role": "AXWindow"})
+    assert "portable" not in text
+
+
 def test_an_action_reports_what_it_logged(writable):
     from keyhac.core import log
 


### PR DESCRIPTION
Fixes #69

**The matcher is deliberately unchanged.** Two findings shaped this:

- The headline repro (`role="Row"` finding nothing where `describe_screen` showed `AXRow`) does not reproduce against the current matcher — that direction works and is pinned by `test_role_matches_with_or_without_the_ax_prefix`. On 2.2.3 the likely culprit was depth: the tool had no `max_depth` parameter yet (added in #75), and Chrome table rows sit far below the default 14.
- Proposal 1 (normalize so `AXRow` also matches Windows' bare `Row`) was considered and rejected: "AX" is macOS vocabulary, and exporting it to Windows' role names would blur a boundary the docs are honest about. `Row` matching both is the convenient direction and already works; the opposite direction stays deliberate.

What issue #69 actually measured was the *rediscovery cost*: nothing at call time says an AX-prefixed pattern is the non-portable spelling, and it cost a session several iterations. So:

- `find_elements`' no-match reply now appends a hint when the role pattern has an AX-prefixed alternation branch, naming the concrete unprefixed spelling to try (`role="AXRow|Cell"` → `try role="Row|Cell"`). The hint is **syntactic**, read off the pattern alone — the no-match path stays a single walk, per the constraint issue #76 records (`test_a_no_match_stays_plain_even_when_the_walk_was_cut` still passes untouched). Wildcard-led remainders are left alone: stripping `AX*` would turn "every AX-prefixed role" into "everything" (`test_a_wildcard_ax_pattern_gets_no_suggestion`).
- The role schema description teaches the rule statically: the prefix may be dropped in the pattern; an AX-prefixed pattern matches only macOS roles.

Proposal 2's counting variant ("matched 12 for AXRow — did you mean that?") is not implemented: the counts would require the second walk that was deliberately reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)