### PR TITLE
find_elements places each match by its ancestor path

### DIFF
--- a/doc/ai-integration.md
+++ b/doc/ai-integration.md
@@ -511,7 +511,7 @@ coordinates, or bindings it never checked.
 |---|---|
 | `list_windows`, `get_focus` | what is open, what is focused |
 | `describe_screen` | a window's element tree as indented text |
-| `find_elements` | targeted search by role / name / identifier / text |
+| `find_elements` | targeted search by role / name / identifier / text, each match placed by its ancestor path |
 | `read_text` | an element's whole text — terminal scrollback, editor buffer |
 | `enable_content_access` | make a Chromium/Electron app expose its content (macOS) |
 | `describe_keymap` | the key tables, which match the current focus, and what each binds |

--- a/keyhac/core/uitree.py
+++ b/keyhac/core/uitree.py
@@ -112,6 +112,16 @@ class UINode:
     children: list["UINode"] = field(default_factory=list)
     truncated: bool = False
 
+    # Structural parent within the walk that built this node - private
+    # plumbing for the MCP ancestor path (issue #55), not public shape, and
+    # deliberately not a dataclass field: a back-edge in __eq__ would recurse
+    # forever through the cycle, and the semantics that would freeze on
+    # publication are awkward (under the DAG dedupe a shared cell's parent is
+    # whichever of row/column the walk reached first; under a roles= filter
+    # it is the nearest *reported* ancestor). None on a walk's root and on
+    # the shallow nodes ui.window()/ui.node() return. Promotable later.
+    _parent = None
+
     @property
     def text(self) -> str:
         """This element's own label and content, as one string.
@@ -415,10 +425,15 @@ def get_ui_tree(root, max_depth: int = DEFAULT_MAX_DEPTH,
             if built is None:
                 continue
             if roles is None or match_role(built.role, roles):
+                built._parent = node
                 node.children.append(built)
             else:
                 # Not reported, but its matching descendants still are, so a
-                # roles= filter cannot lose a cell by way of its row.
+                # roles= filter cannot lose a cell by way of its row.  They
+                # are re-pointed too: the parent chain describes the reported
+                # tree, never a node the caller cannot see.
+                for hoisted in built.children:
+                    hoisted._parent = node
                 node.children.extend(built.children)
         return node
 

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -137,6 +137,47 @@ def _portable_role_spelling(pattern: str) -> str | None:
     return "|".join(stripped)
 
 
+#: Ceiling on a name used as a path qualifier - one line per match has to
+#: stay readable, and the qualifier exists to split twins, not to quote them.
+PATH_NAME_CHARS = 30
+
+
+def _path_segment(node) -> str:
+    """One ancestor as role(qualifier) - at most one qualifier.
+
+    The identifier when there is one, else the name, else the bare role:
+    the path exists to tell two same-role containers apart (issue #55),
+    not to re-dump the tree, so one discriminating fact per level is the
+    budget.
+    """
+    role = node.role or "?"
+    if node.identifier:
+        return f"{role}(#{node.identifier})"
+    if node.name:
+        name = str(node.name)
+        if len(name) > PATH_NAME_CHARS:
+            name = name[:PATH_NAME_CHARS] + "…"
+        return f"{role}({name})"
+    return role
+
+
+def _ancestor_path(node) -> str:
+    """A match's ancestors, root-first, slash-joined; "" on the root itself.
+
+    Read off the same walk that found the match - the `_parent` back-edges
+    `get_ui_tree` records - so it describes the searched snapshot, not a
+    second one.  Where the DAG dedupe applies, a shared node's chain is the
+    side the walk reached first, which is the honest description of the
+    reported tree.
+    """
+    segments = []
+    current = getattr(node, "_parent", None)
+    while current is not None:
+        segments.append(_path_segment(current))
+        current = getattr(current, "_parent", None)
+    return "/".join(reversed(segments))
+
+
 def _running_action(name: str):
     """A running action filed under `name`, whoever started it.
 
@@ -230,9 +271,11 @@ class ToolRegistry:
                  self.describe_screen),
             Tool("find_elements",
                  "Search a window for elements matching role / name / value / "
-                 "identifier / text, and report what each one is. Use when a "
-                 "full tree is more than you need, or to check that a "
-                 "selector you are about to write actually matches.",
+                 "identifier / text, and report what each one is, with its "
+                 "ancestor path - which is how to tell two same-role "
+                 "containers apart. Use when a full tree is more than you "
+                 "need, or to check that a selector you are about to write "
+                 "actually matches.",
                  {"type": "object", "properties": {
                      **window_args,
                      "role": {**string, "description": "Role pattern. The AX "
@@ -567,7 +610,11 @@ class ToolRegistry:
             return text
         lines = [f"{len(matches)} match(es):"]
         for node in matches[:int(limit)]:
-            lines.append(f"  {node!r} value={node.value!r} rect={node.rect}")
+            line = f"  {node!r} value={node.value!r} rect={node.rect}"
+            path = _ancestor_path(node)
+            if path:
+                line += f" path={path}"
+            lines.append(line)
         if len(matches) > int(limit):
             lines.append(f"  ... and {len(matches) - int(limit)} more")
         return "\n".join(lines)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -410,6 +410,39 @@ def test_a_match_found_with_an_ax_pattern_gets_no_hint(registry):
     assert "portable" not in text
 
 
+def test_find_elements_names_each_matchs_ancestors(registry):
+    """Issue #55: two same-role matches are told apart by their ancestor
+    paths in one call, instead of by three dumps with different filters."""
+    from keyhac.core.uitree import UINode
+
+    root = UINode(role="AXWindow", name="Translate")
+    left = UINode(role="AXTabGroup", identifier="source")
+    right = UINode(role="AXTabGroup", name="Target")
+    button_l = UINode(role="AXButton", name="English")
+    button_r = UINode(role="AXButton", name="English")
+    left._parent = root
+    right._parent = root
+    button_l._parent = left
+    button_r._parent = right
+    registry.keymap.node.find_all = lambda **criteria: [button_l, button_r]
+    text = registry.call("find_elements", {"role": "Button"})
+    assert "path=AXWindow(Translate)/AXTabGroup(#source)" in text
+    assert "path=AXWindow(Translate)/AXTabGroup(Target)" in text
+
+
+def test_a_match_that_is_the_searched_root_carries_no_path(registry):
+    """A parentless match - the searched root itself - gets no empty
+    path= fragment, and the line keeps its established shape."""
+    from keyhac.core.uitree import UINode
+
+    window = UINode(role="AXWindow", name="Main", rect=(0, 0, 100, 100))
+    registry.keymap.node.find_all = lambda **criteria: [window]
+    text = registry.call("find_elements", {"role": "Window"})
+    assert text == ("1 match(es):\n"
+                    "  UINode(AXWindow name='Main') value=None "
+                    "rect=(0, 0, 100, 100)")
+
+
 def test_an_action_reports_what_it_logged(writable):
     from keyhac.core import log
 

--- a/tests/test_uitree.py
+++ b/tests/test_uitree.py
@@ -122,6 +122,34 @@ def test_roles_filter_keeps_descendants_of_unmatched_parents():
         ["r0c0", "r0c1", "r1c0", "r1c1"]
 
 
+def test_the_walk_records_each_nodes_parent():
+    """Private back-edges for the MCP ancestor path (issue #55): each
+    reported node points at the node it hangs from, the root at nothing, and
+    a deduped shared cell at whichever side the walk reached first."""
+    tree = get_ui_tree(table_with_shared_cells())
+    assert tree._parent is None
+    row = tree.children[0]
+    assert row._parent is tree
+    a_cell = row.children[0]
+    assert a_cell._parent is row            # rows walk first; columns lose
+    assert a_cell.children[0]._parent is a_cell
+
+
+def test_the_roles_filter_reparents_hoisted_children():
+    """A hoisted child's parent is the nearest *reported* ancestor - the
+    chain never names a node the caller cannot see."""
+    tree = get_ui_tree(table_with_shared_cells(), roles="AXStaticText")
+    assert all(n._parent is tree for n in tree.children)
+
+
+def test_find_all_matches_reach_the_searched_root_through_parents():
+    matches = find_elements(table_with_shared_cells(), role="AXStaticText")
+    node = matches[0]
+    while node._parent is not None:
+        node = node._parent
+    assert node.role == "AXTable"
+
+
 # -- the node projection ----------------------------------------------------
 
 def test_text_keeps_falsy_values():


### PR DESCRIPTION
Fixes #55

Telling two same-role containers apart (the issue's two-`AXTabGroup` case) cost three dumps with different filters. The walk knew each match's ancestry all along and discarded it — `UINode` had no parent link, and the tree died inside `uitree.find_elements` before the tool saw the matches. So:

- `get_ui_tree.build()` records a **private `_parent` back-edge** as it attaches each node. Under a `roles=` filter, hoisted children are re-pointed to the nearest *reported* ancestor, so the chain never names a node the caller cannot see.
- The MCP `find_elements` line grows ` path=AXWindow(Translate)/AXTabGroup(#source)` — root first, slash-joined (the focus-path precedent), one discriminating qualifier per level: `#identifier` when present, else the name truncated to 30 chars, else the bare role. A match that *is* the searched root gets no `path=` fragment.

Design notes, recorded as decisions:

- `_parent` is deliberately **not public shape** (unannotated class attribute, not a dataclass field): the semantics that would freeze on publication are awkward — under the DAG dedupe a shared cell's parent is whichever of row/column the walk reached first, and `ui.window()`/`ui.node()` snapshots have no parent at all. A dataclass field would also need `compare=False` to keep the generated `__eq__` from recursing through the cycle. Promotable later if actions grow the need, per issue #76's spend-surface-only-on-second-consumer rule. It is invisible to lazydocs, `__eq__`, and `asdict` — `make api-reference-check` passes untouched.
- A retained match now keeps the whole walked tree alive through the chain (bounded by `max_nodes`) — accepted deliberately rather than by accident.
- The path describes the searched snapshot, not a second one: no extra walk on any path.

New pins: parent recording incl. the dedupe and reparent cases (`test_the_walk_records_each_nodes_parent`, `test_the_roles_filter_reparents_hoisted_children`, `test_find_all_matches_reach_the_searched_root_through_parents`), the rendered path telling twins apart (`test_find_elements_names_each_matchs_ancestors`), and — for the first time — the existing match-line shape (`test_a_match_that_is_the_searched_root_carries_no_path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)