### PR TITLE
The unknown-flag warning was only noise

### DIFF
--- a/keyhac/platform/mac/hook.py
+++ b/keyhac/platform/mac/hook.py
@@ -339,7 +339,11 @@ class MacInputHook(InputHook):
                     break
                 changed_flags = _KEYCODE_FLAGS.get(key_code, 0)
                 if changed_flags == 0:
-                    logger.warning(f"Flag changed for unknown reason - vk={key_code}")
+                    # A flagsChanged for a keycode outside the modifier map
+                    # changes no flag this engine tracks, so passing it
+                    # through untouched is the whole handling. macOS does
+                    # emit these - the screenshot UI posts one with vk=0
+                    # (issue #30) - and warning about them was only noise.
                     break
                 down = bool(Quartz.CGEventGetFlags(event) & changed_flags)
             else:


### PR DESCRIPTION
Fixes #30

`WARNING [keyhac.MacHook] Flag changed for unknown reason - vk=0` fired whenever a flagsChanged event carried a keycode outside the modifier map — which macOS legitimately produces, e.g. the screenshot UI posts one with vk=0.

The event is provably benign on this path: a keycode with no entry in `_KEYCODE_FLAGS` changes no flag the modifier engine tracks, and the handler already passes the event through untouched. So the warning suggested something needed attention when the pass-through *was* the whole handling. The warning is removed and the reasoning stays as a comment at the site, with the issue reference.

No behavior change beyond the log line; full suite green (the macOS hook path has no hermetic test coverage of this branch, and nothing referenced the message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)