### PR TITLE
The chooser's highlight stays on screen (needs puikit 1.0.12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,16 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    # 1.0.10 is the first release with every puikit API/fix keyhac uses:
+    # 1.0.12 is the first release with every puikit API/fix keyhac uses:
     # set_tray(image=) (PR #82), main-window visibility (PR #84), the LogView
-    # sized-font clip fix the 11pt console log needs (PR #86), and per-window
-    # IME input contexts (PR #90) - without that last one the chooser's filter
+    # sized-font clip fix the 11pt console log needs (PR #86), per-window
+    # IME input contexts (PR #90) - without that one the chooser's filter
     # box accepts ASCII and never composes Japanese, which is issue #20 and is
-    # what doc/dev/testing.md's IME pass verifies. To develop against a local
+    # what doc/dev/testing.md's IME pass verifies - and ListView scrolling an
+    # assigned selection into view (puikit PR #95), which is what keeps the
+    # chooser's highlight on screen (issue #27). To develop against a local
     # checkout, set PUIKIT_DIR (see Makefile).
-    "puikit>=1.0.10",
+    "puikit>=1.0.12",
     'pyobjc-framework-Cocoa>=10; sys_platform == "darwin"',
     'pyobjc-framework-Quartz>=10; sys_platform == "darwin"',
     'pyobjc-framework-ApplicationServices>=10; sys_platform == "darwin"',

--- a/tests/test_chooser.py
+++ b/tests/test_chooser.py
@@ -76,6 +76,25 @@ class TestChooserSingleInstance:
         assert action.chosen == []
 
 
+class TestChooserScrolling:
+    """Issue #27: the chooser routes keys itself and assigns the list's
+    `selected` directly, so the scroll has to come with the assignment -
+    puikit >= 1.0.12 scrolls the selection into view on assignment."""
+
+    def test_selection_moved_past_the_viewport_stays_visible(self, ui_backend):
+        from puikit.event import Event, EventType
+        from keyhac.ui.chooser import ChooserWindow
+
+        items = [("*", f"entry {i:02}", i) for i in range(40)]
+        chooser = ChooserWindow(ui_backend, items)
+        for _ in range(30):
+            chooser._on_event(Event(type=EventType.KEY, key="down"))
+        assert chooser._list.selected == 30
+        rows = ["".join(row) for row in chooser.window.snapshot()]
+        assert any("entry 30" in row for row in rows), \
+            "the selected row scrolled out of view (issue #27)"
+
+
 class TestChooserCentering:
     """Issue #4: the chooser centers on the focused window's frame.
 


### PR DESCRIPTION
Fixes #27

The chooser routes keys itself and assigns `self._list.selected` directly (chooser.py:110), and puikit's `ListView` scrolled the selection into view only from its **own** key handling — so arrowing past the viewport walked the highlight off-screen. The actual fix is [puikit PR #95](https://github.com/crftwr/puikit/pull/95) (merged): assigning `ListView.selected` now clamps and scrolls into view, per the widget's own documented contract.

Keyhac's side of it:

- **Regression test** `TestChooserScrolling::test_selection_moved_past_the_viewport_stays_visible` — drives a real `ChooserWindow` on the MemoryBackend, arrows 30 rows down, and asserts the selected row is in the window snapshot. Verified to **fail** against unpatched puikit 1.0.11 and pass with the fix.
- **Dependency bump** to `puikit>=1.0.12`, with the pyproject comment updated to say what 1.0.12 adds and why.

⚠️ **Merge after puikit 1.0.12 is on PyPI** — the pin points at a release that does not exist yet (`make tag VERSION=1.0.12` + `make release-github` + `make release-whl` in the puikit repo). The dev venv uses the local checkout, so the suite is green now (532 passed), but a fresh `pip install` from this branch would fail to resolve until the release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)