### PR TITLE
The chooser window gets margins, a framed list, and an aligned magnifier

### DIFF
--- a/keyhac/ui/chooser.py
+++ b/keyhac/ui/chooser.py
@@ -8,14 +8,21 @@ keyhac-mac behavior). Up/Down navigate, Enter chooses, Escape cancels.
 from puikit import Panel, WindowStyle
 from puikit.event import EventType
 from puikit.layout import HSplit, Item, VSplit
-from puikit.widgets import Label, ListView, TextEdit
+from puikit.widgets import Label, LayoutView, ListView, TextEdit
 
 from keyhac.core.const import (
     MODKEY_ALT, MODKEY_CMD, MODKEY_CTRL, MODKEY_SHIFT, MODKEY_WIN,
 )
 from keyhac.core import log
+from keyhac.ui.frame import Frame
 
 logger = log.getLogger("Chooser")
+
+# The window's inner margin, shared by the magnifier<->field spacer so the
+# magnifier sits the same distance from the window edge and the field; and
+# the list frame's interior inset. Both collapse on a character grid.
+_MARGIN_PX = 5
+_LIST_PAD_PX = 3
 
 _EVENT_MODKEYS = {
     "shift": MODKEY_SHIFT, "ctrl": MODKEY_CTRL, "alt": MODKEY_ALT,
@@ -49,20 +56,31 @@ class ChooserWindow:
         self.window.on_event = self._on_event
         self.window.on_close = self._on_user_close
 
-        self._edit = TextEdit(text="", on_change=self._on_filter_change, width=60)
+        # width is a cap, not a request: TextEdit draws at most `width` base
+        # units of its flex slot, so pass the full window width to let the
+        # field fill whatever the layout resolves (the window is not resizable).
+        self._edit = TextEdit(text="", on_change=self._on_filter_change, width=72)
         self._list = ListView(self._labels(), ellipsis="…", elide_where="end")
 
         self.panel = Panel(backend, window=self.window)
-        self.panel.set_layout(VSplit(
+        # align="center" sits the magnifier on the field's text line (the field
+        # box is taller than one text line on pixel backends); the page margin
+        # and the search-row/list gap collapse to nothing on a character grid.
+        page = VSplit(
             Item(HSplit(
-                Item(Label("🔍"), size="content"),
+                Item(Label("🔍"), size="content", align="center"),
+                Item(Label(""), size_px=_MARGIN_PX),
                 Item(self._edit, weight=1),
-                gap=1,
+                gap=0,
             ), size="content"),
-            Item(self._list, weight=1),
-            gap=0,
-        ))
-        self.panel.focus(self._edit)
+            Item(Frame(VSplit(Item(self._list, weight=1)), margin_px=_LIST_PAD_PX),
+                 weight=1),
+            gap=0.3,
+        )
+        self._page = LayoutView(page, margin_px=_MARGIN_PX)
+        self.panel.set_layout(VSplit(Item(self._page, weight=1)))
+        self.panel.focus(self._page)
+        self._page.set_focused(self._edit)
         self.panel.render()
 
     def _center_on(self, rect, clamp_to) -> None:

--- a/keyhac/ui/console.py
+++ b/keyhac/ui/console.py
@@ -25,6 +25,7 @@ from puikit.widgets import Button, Checkbox, DropDown, Label, LayoutView, LogVie
 
 from keyhac.core import log
 from keyhac.core.keymap import _AUTHORING_WINDOW
+from keyhac.ui.frame import Frame
 
 logger = log.getLogger("Console")
 
@@ -52,23 +53,6 @@ _LEVELS = [
 ]
 
 _HEALTH_TICK_INTERVAL = 0.1
-
-_BORDER_STYLE = Style(fg=(120, 120, 132))
-
-
-class Frame(LayoutView):
-    """A LayoutView that draws a clear border line around its own extent.
-    draw_border() also clips the hosted content to the interior, so children
-    can fill up to the line without painting over it."""
-
-    def __init__(self, layout, margin_px: float = 6.0,
-                 line_style: Style = _BORDER_STYLE):
-        super().__init__(layout, margin_px=margin_px)
-        self.line_style = line_style
-
-    def draw(self, ctx) -> None:
-        ctx.draw_border(self.line_style)
-        super().draw(ctx)
 
 
 class ConsoleWindow:

--- a/keyhac/ui/frame.py
+++ b/keyhac/ui/frame.py
@@ -1,0 +1,21 @@
+"""A bordered LayoutView shared by the Keyhac windows (console, chooser)."""
+
+from puikit import Style
+from puikit.widgets import LayoutView
+
+_BORDER_STYLE = Style(fg=(120, 120, 132))
+
+
+class Frame(LayoutView):
+    """A LayoutView that draws a clear border line around its own extent.
+    draw_border() also clips the hosted content to the interior, so children
+    can fill up to the line without painting over it."""
+
+    def __init__(self, layout, margin_px: float = 6.0,
+                 line_style: Style = _BORDER_STYLE):
+        super().__init__(layout, margin_px=margin_px)
+        self.line_style = line_style
+
+    def draw(self, ctx) -> None:
+        ctx.draw_border(self.line_style)
+        super().draw(ctx)


### PR DESCRIPTION
Layout polish for the chooser window (from a screenshot review):

- The magnifier emoji now centers on the search field's text line (`align="center"` — the field box is taller than one text line on pixel backends).
- The field fills its flex slot; its `width` was capping the drawn box at 60 units, leaving dead space at the right of a 72-unit window.
- The page gains a 5px inner margin on all four sides (`LayoutView(margin_px=...)`, the console's idiom).
- A 0.3-unit gap separates the search row from the list.
- The list sits in a bordered frame: the console's `Frame` (a LayoutView that strokes `draw_border` around its extent) moved to the shared `keyhac/ui/frame.py`, and both windows now import it.

A pixel-exact spacer (`size_px`) replaces the one-cell HSplit gap right of the magnifier, so the emoji sits the same distance from the window edge and the field — verified at device-pixel precision on the macOS backend (11 device px each side, margins 10 device px on every edge). Margins and spacer collapse to nothing on a character grid; focus/IME routing through the LayoutView wrapper is the same arrangement the console already uses.

Tests: full suite green (531 passed, 17 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)