### PR TITLE
Frame reserves the row its border stroke consumes on snap backends

### DIFF
--- a/keyhac/ui/frame.py
+++ b/keyhac/ui/frame.py
@@ -16,6 +16,22 @@ class Frame(LayoutView):
         super().__init__(layout, margin_px=margin_px)
         self.line_style = line_style
 
+    def _reserve_stroke(self, lctx) -> None:
+        # On snap backends the pixel margin collapses to zero while the border
+        # stroke still consumes a whole base unit per edge, so the hosted
+        # layout must be inset by that unit itself — otherwise its first and
+        # last rows land under the border's content clip and silently vanish
+        # (a ListView scrolled its selection into a row that was never shown).
+        # On pixel backends the stroke is one device pixel, already inside the
+        # pixel margin.
+        if lctx.snap:
+            self.margin_units = max(self.margin_units, 1.0)
+
+    def measure(self, ctx, axis, available):
+        self._reserve_stroke(ctx)
+        return super().measure(ctx, axis, available)
+
     def draw(self, ctx) -> None:
+        self._reserve_stroke(ctx.layout_context())
         ctx.draw_border(self.line_style)
         super().draw(ctx)


### PR DESCRIPTION
Merging #86 turned main red: `TestChooserScrolling::test_selection_moved_past_the_viewport_stays_visible` fails on main while it passed on the branch. The two PRs merged cleanly text-wise but collide semantically with #87's framed chooser list.

**The bug.** On snap (whole-base-unit) backends, `Frame`'s `margin_px` collapses to zero, so the hosted layout is laid out over the frame's full extent — while `draw_border`'s content clip removes one base unit per edge. The child loses its first and last rows without knowing. The `ListView` dutifully scrolled the selection into view of its believed 19-unit viewport, but the last two of those rows were under the border clip, leaving the highlight one row off-screen — exactly the issue #27 symptom, reintroduced by layout accounting rather than a missing scroll. The console's content-sized inspector value panes had the same latent clipping.

**The fix.** `Frame` floors its `margin_units` at the one-unit stroke on snap backends, applied in both `measure` and `draw` so content-sized frames account for it too. Only public PuiKit API is involved (`LayoutContext.snap`, `LayoutView.margin_units`). Pixel backends are untouched: their stroke is one device pixel, already inside the 3–6 px margins the callers pass.

Verified: the chooser snapshot now shows the selected row as the last row inside an intact border; full suite 532 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)