### PR TITLE
A Windows key cannot be a user modifier

### DIFF
--- a/doc/config-api.md
+++ b/doc/config-api.md
@@ -167,6 +167,10 @@ Define a user modifier key.
 
 While defined, the key loses its original meaning entirely: a User0..User3 modifier is never emitted, so assignments hanging off it cannot collide with anything an application understands. 
 
+A Windows key cannot be one, and the call is refused with an error in the log. Defining it does not take the key away from the OS: Keyhac consumes the key-down, so no application ever receives it and the Start menu stays shut, but anything watching the keyboard ahead of Keyhac still sees the physical key held - the Xbox Game Bar opens on Win+G either way, and it swallows that keystroke, including one Keyhac itself injected. A modifier that is invisible to applications but not to the shell is not what this promises, so it is not offered. 
+
+Any other key may be redefined, including one that already is a modifier - ``define_modifier("RAlt", "RUser0")`` works - but prefer a key that is not one: the key stops being Alt (or Ctrl, or Shift) for everything, everywhere, and that is a large thing to give up by accident. Redefining a modifier is noted in the log. 
+
 
 
 **Args:**

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -165,8 +165,8 @@ typo does not leak a stray keystroke into your app).
 ## Remapping and user modifiers
 
 ```python
-keymap.replace_key("CapsLock", "LCtrl")      # swap a key outright
-keymap.define_modifier("RAlt", "RUser0")     # turn a key into your own modifier
+keymap.replace_key("Insert", "LCtrl")        # swap a key outright
+keymap.define_modifier("Apps", "User0")      # turn a key into your own modifier
 ```
 
 - `replace_key` runs before everything else; the rest of the config only ever sees
@@ -175,6 +175,32 @@ keymap.define_modifier("RAlt", "RUser0")     # turn a key into your own modifier
   application sees. While defined, the key loses its original meaning entirely
   (it is never emitted), so `User0-J` bindings cannot clash with anything an app
   understands.
+- Pick a key that is **not** a modifier already. Naming one works, but that key
+  stops being Alt (or Ctrl, or Shift) for everything, everywhere; the log says so
+  when it happens. Not CapsLock either — it reports its own release immediately, so
+  there is no held state to hang a modifier on.
+- `define_modifier("LWin", …)` is refused: a user modifier promises to be invisible
+  to everything, and a Windows key cannot be. Retiring one does not retire it
+  everywhere:
+  - **Win+L still locks the screen.** Windows reserves that combination, like
+    Ctrl+Alt+Del, and handles it before any keyboard hook runs. No program can stop
+    it.
+  - **Win+G still opens the Game Bar**, and swallows the keystroke that opened it —
+    including one Keyhac injected.
+
+  Everything else does go: Win+I, Win+T and their kind do not fire, and no
+  application receives the key. The sample configuration reaches User0 the way
+  Keyhac for Windows always did, retiring both Windows keys first:
+
+  ```python
+  keymap.replace_key("LWin", 235)     # 235, 255: unassigned key codes
+  keymap.replace_key("RWin", 255)
+  keymap.define_modifier(235, "User0")
+  ```
+
+  That is a deliberate trade — the Windows key is the only key every keyboard can
+  spare — and it does not change the two exceptions above. Do not begin an action
+  bound under that modifier by typing `g`.
 
 **One-shot modifiers** (`O-` prefix) give a modifier key a second life: held with
 another key it modifies as usual; tapped *alone*, it fires the one-shot binding.

--- a/doc/dev/design-notes.md
+++ b/doc/dev/design-notes.md
@@ -11,15 +11,120 @@ rich clipboard formats).
 - `KeyCondition` hashes by vk only, with an L/R-agnostic `__eq__` — the dict-lookup
   trick behind side-agnostic matching.
 - Output resolves modifiers to **left-side** physical keys (`force_LR`).
-- User modifiers are never physically emitted (except during replay).
+- User modifiers are never physically emitted (except during replay). The Win keys
+  are refused as user modifiers rather than made an exception to this — see below.
 - An unmatched key-down leaving multi-stroke mode is still consumed (no stray
   keystroke leaks into the app).
 - Errors in user callables pass the key through — typing keeps working on a broken
   config.
+- A lone held Win/Alt is fenced with a Ctrl tap on Windows, so the OS does not read
+  it as a tap on the key itself — see below.
 - Three upstream keyhac-mac hook bugs are intentionally *fixed* in the mac hook port —
   see the module docstring of `keyhac/platform/mac/hook.py`. The third (fresh real
   input overtaking re-posted deferred reals during the flush window) was found by the
   ordering verification in [testing.md](testing.md).
+
+## Why a Windows key cannot be a user modifier
+
+`define_modifier` refuses `LWin` / `RWin`. The reason is that consuming a key-down
+does not take the key away from everything.
+
+The Windows sample configuration nevertheless reaches User0 through the Win key, via
+`replace_key("LWin", 235)` — the route keyhac-win always took, and one the refusal
+does not close. That is deliberate, not an oversight: `define_modifier` promises a
+modifier nothing outside Keyhac can see, and that promise it cannot keep for a Win
+key; `replace_key` promises only "this key is now that key", which is true. Windows
+has no other key every keyboard can spare, so the alternative was no sample user
+modifier at all. What the operator has to know is in the template's own comment: an
+action under that modifier must not begin by typing `g`, and Win+L still locks.
+
+Returning 1 from `WH_KEYBOARD_LL` keeps the Win key-down out of every message queue,
+and that much works: no application receives it, and the Start menu does not open on
+a tap (the shell decides that on the key-up, which is consumed too). Two things
+survive it anyway.
+
+**Win+L locks the screen.** Windows reserves that combination, like Ctrl+Alt+Del,
+and resolves it before the hook chain runs, so the physical Win key is tracked
+somewhere below where any program can reach. Nothing Keyhac does — consuming,
+renaming through `replace_key` — changes it.
+
+**Win+G opens the Game Bar, and it eats the keystroke.** Live findings, with
+`define_modifier("LWin", "LUser0")` in effect:
+
+- an unbound `LWin-G` opened the Game Bar, although Keyhac emits no Win key at all
+  and the binding could not match (`LWin-G` parses to `MODKEY_WIN_L`, and the key
+  now produces `MODKEY_USER0_L`);
+- `U0-G` bound to an action typing "git status" typed **"it status"** — the injected
+  `g` was swallowed as Win+G. The other letters survived: `Win+I`, `Win+T`, `Win+S`
+  and `Win+A` are shell hotkeys, and those go through the path that *did* honour the
+  consume.
+
+None of this is new. All of it reproduces on keyhac-win 1.83 - the released build,
+run portable with its stock configuration, on the same machine, with the Win keys
+retired by `replaceKey`/`defineModifier` exactly as that configuration ships them.
+Win+L locks; Win+G opens the Game Bar; and a `U0-G` bound to
+`InputKeyCommand("G","I","T",...)` types "it status" there too. The same command
+under a real Alt (`A-G`) keeps its `g`, which places the loss on the Win key being
+held rather than on anything about the head of an injected batch. So this is not a
+Keyhac2 regression; the Win key has never been fully retirable, and the sample
+configuration inherits the trade rather than introducing it.
+
+By what route the Game Bar sees the key is **not settled**. It is not the route a
+bystander would take: a probe that consumes a physical key in its own low-level hook
+and watches for it on the two channels open to any process — `GetAsyncKeyState` and
+a raw input sink — sees nothing on either, for a Win key and for an ordinary key
+alike (`tools/`-grade scratch probe, not in the suite; the same probe with the key
+passed through registers on both channels, which is what validates it). So a hook
+installed *after* Keyhac's, and therefore called before it, remains the most likely
+explanation, and the reserved-combination path that Win+L proves exists is the other
+candidate. Restarting Keyhac (making its hook the most recent) would separate them
+and has not been tried.
+
+Two dead ends, both measured:
+
+- keyhac-win's idiom — `replaceKey("LWin", 235)` then `defineModifier(235, "User0")`,
+  which is how its sample configuration reached User0 — changes nothing. It renames
+  the key inside Keyhac; the physical event is identical.
+- Injecting a Win key-up at the head of each batch *does* fix it, and does not open
+  the Start menu. It was implemented and then dropped: it makes a user modifier emit
+  an unmatched key-up, which is a hole in the invariant above, and it leaves the OS
+  believing the key is released while the user is still holding it. A modifier that
+  is invisible to applications but not to the shell is not what `define_modifier`
+  promises, so the key is refused instead of patched around.
+
+keyhac-win refused *every* key that already was a modifier. Keyhac2 refuses only the
+Win keys: the rest of that rule would break `define_modifier("RAlt", "RUser0")`,
+which migrated keyhac-mac configurations use. Redefining a modifier is reported at
+INFO rather than refused — legitimate, but it costs that key its modifier
+everywhere, so the sample no longer demonstrates the feature that way.
+
+Related, and a separate problem — about *real* Win/Alt, not user modifiers: a held
+Win or Alt whose companion key Keyhac consumed reaches the OS as a lone tap, opening
+the Start menu or moving focus to the menu bar. keyhac-win cancelled that with a
+`VK_LCONTROL` tap, in two places, and both are ported (Windows only; macOS has no
+such behavior to cancel):
+
+- `InputContext.send_modifier_keys` taps Ctrl between its press and release loops
+  whenever a lone Win/Alt is being released or taken — the transitions that
+  reconciling modifiers around a batch produces.
+- `Keymap._cancel_oneshot_win_alt` taps before a callable action runs and before
+  entering a multi-stroke table, for actions that emit no key output at all.
+
+A callable that *does* send keys therefore emits the tap three times, which is what
+keyhac-win emitted too, and none of the three is safe to drop on its own:
+
+```
+SEND : D-LCtrl U-LCtrl                          <- before the callable
+SEND : D-LCtrl U-LCtrl U-LAlt D-G ... D-LAlt D-LCtrl U-LCtrl
+```
+
+The last one is unconditional: the re-pressed `D-LAlt` is a fresh Alt-down as far as
+the OS is concerned, so the user's own eventual release opens the menu bar unless
+something marks it used. The middle one is the only chance a key-output assignment
+gets — those never reach `_cancel_oneshot_win_alt`. The first is the only chance an
+action that emits nothing at all gets. The redundancy is between the first two, and
+only for the case where the callable happens to send keys, which cannot be known
+before running it.
 
 ## Clipboard history
 

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -155,6 +155,36 @@ macOS 15 on this machine). Highlights and the bugs the passes caught:
   trigger re-install, and consumption works again after. Note: this Windows build
   survives a 0.6 s callback stall without unhooking, so the silent-unhook path
   cannot be provoked via `LowLevelHooksTimeout` here.
+- **A Win key as a user modifier, on Windows 11** — the pass that produced the
+  refusal in `define_modifier` ([design-notes.md](design-notes.md#why-a-windows-key-cannot-be-a-user-modifier)).
+  With `define_modifier("LWin", "LUser0")`: an unbound `LWin-G` opened the Game Bar
+  even though Keyhac emits no Win key, and a `U0-G` action typing "git status" typed
+  "it status" — the injected `g` eaten as Win+G, every other letter arriving. Also
+  measured: `replace_key("LWin", 235)` + `define_modifier(235, "LUser0")` changes
+  nothing; the same user modifier on `RAlt` is clean; and injecting `U-LWin` at the
+  head of the batch fixes the typing *and* does not open the Start menu. Also
+  confirmed: `Win+L` locks the screen with the Win key retired, which is Windows
+  reserving that combination ahead of the hook chain and is not fixable. Reproducing
+  any of this needs a real Game Bar, so none of it is in the automated suite.
+
+  A scratch probe that consumes a physical key in its own low-level hook while
+  watching `GetAsyncKeyState` and a raw input sink shows *nothing* surviving the
+  consume, for a Win key or an ordinary one - with the key passed through, both
+  channels register, which is what makes the negative readable. So the Game Bar is
+  not reading either of those. Which route it does use is still open.
+
+  Checked against keyhac-win 1.83 on the same machine - the released build run
+  portable (a `config.py` beside `keyhac.exe` keeps it off `~/.keyhac`), stock
+  configuration, Keyhac2 shut down: `Win+L` locks, `Win+G` opens the Game Bar, and a
+  `U0-G` bound to `InputKeyCommand("G","I","T",...)` types "it status". The same
+  command under a real Alt keeps its `g` and does not move focus to Notepad's menu
+  bar - which is `cancel_oneshot_win_alt` working upstream, and the behavior the
+  Keyhac2 port reproduces. The behavior is inherited, not a regression.
+- **Lone Win/Alt cancelling** (Notepad, Windows 11): `kt["Alt-G"]` bound to an
+  action, triggered with Alt physically held. The action runs and the menu bar does
+  not take focus - the `VK_LCONTROL` tap marks the modifier used before the Alt is
+  released and again after it is re-pressed. Notepad is the check that matters here:
+  it has a menu bar to lose focus into.
 - **Chooser paste flow end-to-end** (14/14): open-with-focus, filter, Enter →
   refocus original cross-process app → Ctrl-V into a real EDIT control; Shift-Enter
   copy-only; hotkey toggle.

--- a/keyhac/_config.py
+++ b/keyhac/_config.py
@@ -30,18 +30,41 @@ def configure(keymap):
     # Turn a key into User0, a modifier of your own that no application
     # sees.  User0-User3 are available; a key used this way is never
     # emitted, so it loses its original meaning while defined.
-    if mac:
-        # The right Option key; it stops acting as Option.
-        keymap.define_modifier("RAlt", "RUser0")
-    else:
-        # The left Windows key; the Start menu no longer opens on a tap
-        # (bind kt["O-LWin"] = "LWin" below if you want that back).
-        keymap.define_modifier("LWin", "LUser0")
+    #
+    # Pick a key that is not a modifier already.  Naming one here does work,
+    # but that key then stops being Alt (or Ctrl, or Shift) for everything,
+    # everywhere - a large thing to give up by accident.
+    #
+    # Windows has no spare key on every keyboard, so the Windows keys are
+    # retired instead: replace_key renames them to codes Windows has no
+    # meaning for, and the left one becomes User0.  This is what Keyhac for
+    # Windows always did, and define_modifier("LWin", ...) is refused
+    # directly, because retiring a Win key does not retire it everywhere:
+    #
+    #   Win+L still locks the screen.  Windows reserves that combination
+    #     (like Ctrl+Alt+Del) and handles it before any keyboard hook runs.
+    #     Nothing running as a program can stop it.
+    #   Win+G still opens the Game Bar, and swallows the keystroke that
+    #     opened it - including one Keyhac injected.  So an action bound
+    #     under User0 should not start by typing "g".
+    #
+    # The rest is gone as promised: Win+I, Win+T and their kind do not fire,
+    # and no application receives the key.
+    #
+    # macOS needs none of this - it has Fn, which no application uses as a
+    # shortcut modifier - so the samples below hang off Fn there.  To define
+    # one anyway, name a key you can spare: keymap.define_modifier("F13",
+    # "User0").  Not CapsLock: it reports its own release immediately, so
+    # there is no "held" state to hang a modifier on.
+    if not mac:
+        keymap.replace_key("LWin", 235)     # 235, 255: unassigned key codes
+        keymap.replace_key("RWin", 255)
+        keymap.define_modifier(235, "User0")
 
     # --- the two portability constants ---------------------------------
     # LEADER: the modifier most samples below hang off.
     #   macOS   - the Fn key, which Windows does not expose to software
-    #   Windows - User0, i.e. the left Windows key defined just above
+    #   Windows - User0, i.e. the left Windows key retired just above
     LEADER = "Fn" if mac else "User0"
 
     # MOD: the OS's primary shortcut modifier, so one binding can mean
@@ -50,7 +73,8 @@ def configure(keymap):
 
     # --- swap a key entirely (uncomment to try) ------------------------
     # replace_key runs before any key table, so the rest of the config
-    # only ever sees the replacement.
+    # only ever sees the replacement - the Windows keys above are retired
+    # this way.
     # keymap.replace_key("CapsLock", "LCtrl")
 
     # --- text editor for "Edit Config" ---------------------------------

--- a/keyhac/core/const.py
+++ b/keyhac/core/const.py
@@ -43,6 +43,10 @@ MODKEY_USER1_R = MODKEY_USER1 << (MODKEY_PLANE_BITS * 2)
 MODKEY_USER2_R = MODKEY_USER2 << (MODKEY_PLANE_BITS * 2)
 MODKEY_USER3_R = MODKEY_USER3 << (MODKEY_PLANE_BITS * 2)
 
+#: The Win key in all three planes - the OS keeps hold of this one whatever
+#: Keyhac does with it, so define_modifier refuses it.
+MODKEY_WIN_ALL = MODKEY_WIN | MODKEY_WIN_L | MODKEY_WIN_R
+
 _MODKEY_USER = MODKEY_USER0 | MODKEY_USER1 | MODKEY_USER2 | MODKEY_USER3
 
 MODKEY_USER_ALL = (

--- a/keyhac/core/input.py
+++ b/keyhac/core/input.py
@@ -9,6 +9,19 @@ Ported from keyhac-mac keyhac_input.py.  Differences:
 from keyhac.core.const import *
 from keyhac.core.key import KeyCondition
 from keyhac.core.vk import KeyNames, get_key_names
+from keyhac.core import log
+
+logger = log.getLogger("Input")
+
+
+def _format_item(item) -> str:
+    """One queued item as readable text, for the SEND debug log."""
+    if item[0] == "text":
+        return f"text({item[1]!r})"
+    if item[0] == "mouse":
+        return f"mouse{item[1]!r}"
+    vk, down = item
+    return ("D-" if down else "U-") + get_key_names().vk_to_str(vk)
 
 
 class InputContext:
@@ -224,6 +237,23 @@ class InputContext:
         lazydocs: ignore
         """
 
+        # A lone Win or Alt press means something to Windows by itself - the
+        # Start menu opens, the menu bar takes focus - and reconciling the
+        # modifiers around a batch produces exactly that shape: the key goes
+        # up (and later down again) with nothing pressed in between, because
+        # what the user actually pressed was consumed.  A Ctrl tap between the
+        # two loops below is what marks the modifier as used.  Port of
+        # keyhac-win setInput_Modifier's cancel_oneshot_win_alt; macOS has no
+        # such behavior to cancel, and the tap would be pure noise there.
+        cancel_win_alt = False
+        if self._keymap.platform == "windows":
+            if mod == 0 and (mod_eq(self._virtual_modifier, MODKEY_ALT)
+                             or mod_eq(self._virtual_modifier, MODKEY_WIN)):
+                cancel_win_alt = True
+            elif self._virtual_modifier == 0 and (mod_eq(mod, MODKEY_ALT)
+                                                  or mod_eq(mod, MODKEY_WIN)):
+                cancel_win_alt = True
+
         # Key down modifiers that are missing
         for vk, modkey in self._vk_mod_map.items():
             # User modifiers are never physically emitted (except in replay
@@ -233,6 +263,11 @@ class InputContext:
             if not (modkey & self._virtual_modifier) and (modkey & mod):
                 self._input_seq.append((vk, True))
                 self._virtual_modifier |= modkey
+
+        if cancel_win_alt:
+            ctrl_vk = get_key_names().str_to_vk("LCtrl")
+            self._input_seq.append((ctrl_vk, True))
+            self._input_seq.append((ctrl_vk, False))
 
         # Key up modifiers that must not be held
         for vk, modkey in self._vk_mod_map.items():
@@ -245,6 +280,14 @@ class InputContext:
     def _flush(self):
         self.send_modifier_keys(self._real_modifier)
         seq, self._input_seq = self._input_seq, []
+
+        # What actually leaves Keyhac, before it is split into platform
+        # batches - the counterpart of keyhac-win's "OUT :" line.  Without it
+        # the log shows which action ran but not one byte of what it emitted,
+        # and questions like "is the modifier released around this batch?"
+        # cannot be answered from a log at all.
+        if seq:
+            logger.debug("SEND     : " + " ".join(_format_item(i) for i in seq))
 
         # Consecutive items of one kind go out as one platform batch; a kind
         # change flushes, so overall ordering is preserved across the key /

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -36,6 +36,21 @@ _MODIFIER_BITS = (
 )
 
 
+def _modifier_name(mod: int) -> str:
+    """A modifier bit mask as its name, sided when it is one side only."""
+    names = []
+    for name, generic in _MODIFIER_BITS:
+        left = generic << MODKEY_PLANE_BITS
+        right = generic << (MODKEY_PLANE_BITS * 2)
+        if mod & generic or (mod & left and mod & right):
+            names.append(name)
+        elif mod & left:
+            names.append(f"L{name}")
+        elif mod & right:
+            names.append(f"R{name}")
+    return "+".join(names) if names else "(none)"
+
+
 #: How long the MCP endpoint stays open once switched on, in seconds.
 #:
 #: One switch with a deadline rather than a switch you remember to turn off.
@@ -474,6 +489,21 @@ class Keymap:
         User0..User3 modifier is never emitted, so assignments hanging off it
         cannot collide with anything an application understands.
 
+        A Windows key cannot be one, and the call is refused with an error
+        in the log. Defining it does not take the key away from the OS:
+        Keyhac consumes the key-down, so no application ever receives it and
+        the Start menu stays shut, but anything watching the keyboard ahead
+        of Keyhac still sees the physical key held - the Xbox Game Bar opens
+        on Win+G either way, and it swallows that keystroke, including one
+        Keyhac itself injected. A modifier that is invisible to applications
+        but not to the shell is not what this promises, so it is not offered.
+
+        Any other key may be redefined, including one that already is a
+        modifier - ``define_modifier("RAlt", "RUser0")`` works - but prefer a
+        key that is not one: the key stops being Alt (or Ctrl, or Shift) for
+        everything, everywhere, and that is a large thing to give up by
+        accident. Redefining a modifier is noted in the log.
+
         Args:
             key: Key to use as the modifier, as a key name or a virtual key
                 code.
@@ -494,6 +524,27 @@ class Keymap:
         except (ValueError, TypeError):
             logger.error(f"Invalid modifier expression for argument 'mod': {mod}")
             return
+        # keyhac-win refused every key that already was a modifier, and its
+        # sample configuration went through replaceKey to reach the Win key.
+        # Only the Win keys are refused here - the rest of that rule would
+        # break define_modifier("RAlt", "RUser0"), which both the macOS
+        # sample and keyhac-mac configurations have always used. Laundering
+        # the key through replace_key does not help either: what still holds
+        # the Win key is the OS, which never hears about Keyhac's renaming.
+        if self._vk_mod_map.get(key, 0) & MODKEY_WIN_ALL:
+            name = get_key_names().vk_to_str(key)
+            logger.error(f"A Windows key cannot be a user modifier: {name}")
+            return
+        # Redefining a modifier is legitimate, so this is not a warning - but
+        # it is silent about a real loss: that key is not Alt (or Ctrl, or
+        # Shift) for anything, anywhere, any more. Said once, at INFO, which
+        # the console shows by default.
+        if key in self._vk_mod_map:
+            was = _modifier_name(self._vk_mod_map[key])
+            logger.info(
+                f"{get_key_names().vk_to_str(key)} was the {was} modifier and "
+                f"is now {_modifier_name(mod)}; nothing sees {was} from it "
+                f"any more.")
         self._vk_mod_map[key] = mod
 
     def describe_keymap(self, limit: int = 300) -> str:
@@ -844,9 +895,11 @@ class Keymap:
         if callable(action):
             action_name = getattr(action, "__name__", None) or repr(action)
             logger.debug(f"CALL     : {action_name}")
+            self._cancel_oneshot_win_alt()
             action()
 
         elif isinstance(action, KeyTable):
+            self._cancel_oneshot_win_alt()
             self._enter_multi_stroke(action)
 
         else:
@@ -914,6 +967,26 @@ class Keymap:
 
     # ------------------------------------------------------------------
     # Helpers
+
+    def _cancel_oneshot_win_alt(self):
+        """Mark a held lone Win/Alt as used, so releasing it does nothing.
+
+        An action that emits no key output leaves the OS with a Win or Alt
+        that went down and comes back up with nothing in between - the key
+        the user actually pressed was consumed - and Windows reads that as a
+        lone tap: the Start menu opens, or the menu bar takes focus. Injecting
+        a Ctrl tap before the action runs is what keyhac-win did here
+        (_cancelOneshotWinAlt), for the same two cases: a callable, and
+        entering a multi-stroke table.
+
+        Key output does not need this: InputContext.send_modifier_keys emits
+        the same tap while reconciling the modifiers around its batch.
+        """
+        if self.platform != "windows":
+            return
+        if mod_eq(self._modifier, MODKEY_ALT) or mod_eq(self._modifier, MODKEY_WIN):
+            with self.get_input_context() as ctx:
+                ctx.send_modifier_keys(self._modifier | MODKEY_CTRL_L)
 
     def _release_modifier_all(self):
         with self.get_input_context() as ctx:

--- a/tests/test_keymap.py
+++ b/tests/test_keymap.py
@@ -143,6 +143,56 @@ class TestOneShot:
         assert "D-Escape" not in e.sent_names()
 
 
+class TestLoneWinAltCancel:
+    """A held Win/Alt whose companion key Keyhac consumed looks like a lone
+    tap to Windows - Start menu, menu bar - so a Ctrl tap marks it used.
+    Port of keyhac-win's cancel_oneshot_win_alt / _cancelOneshotWinAlt."""
+
+    def _configure(self, keymap):
+        kt = keymap.define_keytable(focus_path_pattern="*")
+        kt["Alt-J"] = lambda: None
+        kt["Win-J"] = lambda: None
+        kt["Alt-Ctrl-J"] = lambda: None
+        kt["Alt-M"] = keymap.define_keytable(name="sub")
+
+    def test_callable_under_lone_alt(self, engine):
+        e = engine(self._configure, platform="windows")
+        e.down("LAlt")
+        e.hook.clear()
+        assert e.down("J") is True
+        assert e.sent_names() == ["D-LCtrl", "U-LCtrl"]
+
+    def test_callable_under_lone_win(self, engine):
+        e = engine(self._configure, platform="windows")
+        e.down("LWin")
+        e.hook.clear()
+        assert e.down("J") is True
+        assert e.sent_names() == ["D-LCtrl", "U-LCtrl"]
+
+    def test_entering_multi_stroke(self, engine):
+        e = engine(self._configure, platform="windows")
+        e.down("LAlt")
+        e.hook.clear()
+        assert e.down("M") is True
+        assert e.sent_names() == ["D-LCtrl", "U-LCtrl"]
+
+    def test_not_a_lone_modifier(self, engine):
+        """Alt+Ctrl released together opens nothing, so nothing to cancel."""
+        e = engine(self._configure, platform="windows")
+        e.down("LAlt")
+        e.down("LCtrl")
+        e.hook.clear()
+        assert e.down("J") is True
+        assert e.hook.sent == []
+
+    def test_macos_has_nothing_to_cancel(self, engine):
+        e = engine(self._configure)
+        e.down("LAlt")
+        e.hook.clear()
+        assert e.down("J") is True
+        assert e.hook.sent == []
+
+
 class TestUserModifier:
 
     def _configure(self, keymap):
@@ -162,6 +212,70 @@ class TestUserModifier:
         assert e.down("J") is True
         # user modifier is not reconciled into physical output
         assert e.sent_names() == ["D-Down", "U-Down"]
+
+    def test_windows_key_is_refused(self, engine):
+        """Keyhac can keep the Win key out of every application, but not out
+        of the shell - a Win-based user modifier still opens the Game Bar on
+        Win+G, and the Game Bar swallows that keystroke. Refused, and the key
+        stays the Win modifier it was."""
+        def configure(keymap):
+            keymap.define_modifier("LWin", "LUser0")
+            kt = keymap.define_keytable(focus_path_pattern="*")
+            kt["U0-J"] = "Down"
+            kt["Win-K"] = "Up"
+
+        e = engine(configure, platform="windows")
+        e.down("LWin")
+        assert e.down("J") is False            # U0-J never armed
+        assert e.down("K") is True             # LWin is still Win
+        # ... and being a real modifier, it is released around the output,
+        # each transition fenced by the lone-Win/Alt cancelling Ctrl tap
+        assert e.sent_names() == ["D-LCtrl", "U-LCtrl", "U-LWin",
+                                  "D-Up", "U-Up",
+                                  "D-LWin", "D-LCtrl", "U-LCtrl"]
+
+    def test_windows_key_retired_through_replace_key(self, engine, caplog):
+        """The sample configuration's route to User0 on Windows: rename the
+        Win keys to codes Windows has no meaning for, and make one of them
+        the modifier. Not blocked by the define_modifier refusal, and not
+        reported as a redefinition - 235 was not a modifier."""
+        def configure(keymap):
+            keymap.replace_key("LWin", 235)
+            keymap.replace_key("RWin", 255)
+            keymap.define_modifier(235, "User0")
+            kt = keymap.define_keytable(focus_path_pattern="*")
+            kt["U0-J"] = "Down"
+
+        with caplog.at_level("INFO", logger="keyhac.Keymap"):
+            e = engine(configure, platform="windows")
+        assert not any("modifier and is now" in r.message
+                       for r in caplog.records)
+        assert e.down("LWin") is True          # consumed, never emitted
+        assert e.hook.sent == []
+        assert e.down("J") is True
+        assert e.sent_names() == ["D-Down", "U-Down"]
+
+    def test_redefining_a_modifier_is_reported(self, engine, caplog):
+        """Legitimate, so not a warning - but the key stops being the modifier
+        it was, everywhere, and that is worth saying out loud."""
+        def configure(keymap):
+            keymap.define_modifier("RAlt", "RUser0")
+            keymap.define_keytable(focus_path_pattern="*")
+
+        with caplog.at_level("INFO", logger="keyhac.Keymap"):
+            engine(configure)
+        assert any("RAlt was the RAlt modifier and is now RUser0" in r.message
+                   for r in caplog.records)
+
+    def test_defining_a_plain_key_says_nothing(self, engine, caplog):
+        def configure(keymap):
+            keymap.define_modifier("F20", "User0")
+            keymap.define_keytable(focus_path_pattern="*")
+
+        with caplog.at_level("INFO", logger="keyhac.Keymap"):
+            engine(configure)
+        assert not any("modifier and is now" in r.message
+                       for r in caplog.records)
 
     def test_user2_user3_supported(self, engine):
         def configure(keymap):


### PR DESCRIPTION
Reported from a live config on Windows 11: `kt["LWin-G"]` never called its function, yet opened the Xbox Game Bar, and `kt["U0-G"]` bound to an action typing "git status" typed **"it status"**.

One cause. Consuming a key-down keeps it out of every message queue — no application receives the Win key, and the Start menu does not open on a tap — but not out of what the Game Bar is reading, so the `g` Keyhac itself injected was taken as Win+G and swallowed. `Win+I`, `Win+T`, `Win+S` and `Win+A` all arrived: those are shell hotkeys, and that path *did* honour the consume.

### What changed

- **`define_modifier` refuses `LWin`/`RWin`.** A user modifier promises to be invisible to everything outside Keyhac, and for a Win key that promise cannot be kept. keyhac-win refused *every* key that already was a modifier; refusing that much here would break `define_modifier("RAlt", "RUser0")`, which migrated keyhac-mac configurations use, so only the Win keys are refused. Redefining any other modifier is reported at INFO.
- **The sample configuration takes keyhac-win's route**, retiring both Windows keys with `replace_key("LWin", 235)` / `("RWin", 255)` and making 235 the User0. `replace_key` promises only "this key is now that key", which is true, and Windows has no other key every keyboard can spare.
- **`cancel_oneshot_win_alt` / `_cancelOneshotWinAlt` are ported** — they had no counterpart here. A genuinely held Win or Alt whose companion key Keyhac consumed reaches the OS as a lone tap (Start menu, or focus into the menu bar). Both places now emit the same `VK_LCONTROL` tap, Windows only. Verified in Notepad.
- **`InputContext` gains the `SEND` debug line**, keyhac-win's `OUT :` with no counterpart until now. The log named the action that ran and not one byte of what it emitted.

### Measured, and recorded in doc/dev/

Two routes out were tried and rejected: keyhac-win's `replaceKey("LWin", 235)` idiom changes nothing (it renames the key inside Keyhac; the physical event is identical), and injecting a Win key-up at the head of each batch does fix the typing without opening the Start menu, but makes a user modifier emit an unmatched key-up.

A probe that consumes a physical key in its own low-level hook and watches the two channels open to any process — `GetAsyncKeyState` and a raw input sink — sees nothing on either, for a Win key and an ordinary key alike. So the Game Bar is not reading either of those; by what route it does see the key is **not settled** and is written up as open.

**None of it is a regression.** All three symptoms reproduce on keyhac-win 1.83, run portable with its stock configuration on the same machine: `Win+L` locks, `Win+G` opens the Game Bar, and a `U0-G` bound to `InputKeyCommand("G","I","T",...)` types "it status" there too. The same command under a real Alt keeps its `g` and leaves the menu bar alone — which is `cancel_oneshot_win_alt` working upstream, and the behavior this port reproduces.

`Win+L` locking with the Win key retired is now documented in the template and in `doc/configuration.md`, alongside `Win+G`: Windows reserves that combination like Ctrl+Alt+Del and resolves it before any hook runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)