### PR TITLE
Keyhac gains a portable IME on/off API

### DIFF
--- a/doc/config-api.md
+++ b/doc/config-api.md
@@ -240,6 +240,29 @@ Get the frontmost window.
 
 ---
 
+### <kbd>method</kbd> `Keymap.get_ime_status`
+
+```python
+get_ime_status() → bool | None
+```
+
+Get whether the IME is on for whatever holds the input focus. 
+
+There is no window argument on purpose: macOS can only ever address the current input source, so naming a window would mean two different contracts on the two OSes. 
+
+
+
+**Returns:**
+  True when the IME is on, False when it is off, or None when the  state cannot be determined - no IME is installed or reachable, or  (Windows) a TSF-only IME does not answer the IMM32 query. 
+
+
+
+**Note:**
+
+> UI-thread only.  On macOS "off" means a plain keyboard layout or an input method's Roman mode is selected, which is close to but not the same thing as Windows' "the IME is closed". 
+
+---
+
 ### <kbd>method</kbd> `Keymap.get_input_context`
 
 ```python
@@ -372,6 +395,33 @@ Get the work area of every screen.
 **Note:**
 
 > UI-thread only - the macOS implementation is an AppKit query. 
+
+---
+
+### <kbd>method</kbd> `Keymap.set_ime_status`
+
+```python
+set_ime_status(on: bool) → bool
+```
+
+Turn the IME on or off for whatever holds the input focus. 
+
+
+
+**Args:**
+ 
+ - <b>`on`</b>:  True to turn the IME on, False to turn it off. 
+
+
+
+**Returns:**
+ Whether the requested state was actually reached - the result is read back rather than assumed, so False means the IME declined or there was none to ask. 
+
+
+
+**Note:**
+
+> UI-thread only.  Whether the change also affects other applications is the user's OS setting ("Let me use a different input method for each app window" on Windows, "Automatically switch to a document's input source" on macOS), not something Keyhac decides. 
 
 ---
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -214,6 +214,51 @@ modifiers first (so a `User0-…` binding does not click with a phantom modifier
 moves keep them. Relative moves are injected acceleration-proof on both OSes, and
 rapid synthetic clicks register as double-clicks.
 
+## IME
+
+```python
+if keymap.get_ime_status():          # True on, False off, None can't tell
+    keymap.set_ime_status(False)     # returns whether the state was reached
+```
+
+Both act on **whatever holds the input focus**, and neither takes a window. That is
+the one contract the two OSes can both honor: Windows reaches the state through a
+window handle and so could address a background window, while macOS only ever
+exposes "the current input source". A window argument would mean two different
+APIs wearing one name.
+
+`get_ime_status()` returns `None` — not `False` — when the state cannot be
+determined: no IME is installed, or on Windows a TSF-only IME that does not answer
+the IMM32 query. `set_ime_status()` reads the state back rather than assuming the
+call took, so its `False` means the IME declined or there was none to ask.
+
+Two caveats worth knowing:
+
+- On macOS, "off" means a plain keyboard layout or an input method's Roman mode is
+  selected. That is close to, but not the same thing as, Windows' "the IME is
+  closed".
+- Turning the IME *on* when it already is leaves the current mode alone, so a
+  binding that asserts "on" will not drag a macOS user out of Katakana back into
+  Hiragana. With several IMEs installed and the IME off, which one "on" picks is
+  the first enabled one — macOS exposes no most-recently-used order.
+- Whether a change also affects *other* applications is the user's OS setting —
+  "Let me use a different input method for each app window" on Windows,
+  "Automatically switch to a document's input source" on macOS — not something
+  Keyhac decides.
+
+For simply toggling, the key names cost nothing and work on both OSes: `Eisu` is
+IME off and `Kana` is IME on, reaching the macOS keys of those names and Windows'
+`VK_IME_OFF` / `VK_IME_ON`.
+
+```python
+kt["O-LCmd"] = "Eisu"        # tap left Cmd alone -> IME off
+kt["O-RCmd"] = "Kana"        # tap right Cmd alone -> IME on
+```
+
+Windows additionally has the physical JIS keys `Kanji` (半角/全角), `Henkan` (変換)
+and `Muhenkan` (無変換), which macOS has no equivalent of — guard those with
+`keymap.platform`.
+
 ## Clipboard
 
 ```python
@@ -418,6 +463,7 @@ focus path — the two things you need when writing new bindings.
 | `keymap.focus` | current `Focus` snapshot |
 | `keymap.get_active_window()` / `list_windows()` / `find_window(...)` | portable `Window` objects; UI thread only |
 | `keymap.screen_frames()` / `screen_work_frames()` / `window_frames()` | screen/window geometry; `screen_work_frames` UI thread only |
+| `keymap.get_ime_status()` / `set_ime_status(on)` | IME on/off for the input focus; UI thread only |
 | `keymap.clipboard_history` | settings + `items()` / `get_current()` / `set_current()` |
 | `keymap.editor` / `edit_config()` / `reload_config()` | config lifecycle (tray menu uses these) |
 | `keymap.replay_buffer` | macro buffer behind the record actions |

--- a/doc/dev/ai-integration.md
+++ b/doc/dev/ai-integration.md
@@ -892,6 +892,13 @@ the action carried on invisibly. Blocking briefly and degrading to polling is wo
 still: two reply shapes whose selection hinges on how fast the action happened to be,
 the least predictable thing available.
 
+Returning at once carries one obligation: the run record is opened by `start_action`
+itself, on the calling thread, and handed to the worker — not opened by the worker. A
+model that starts an action and immediately asks how it went would otherwise be answered
+out of the *previous* run of that name, which is finished, so the wait returns instantly
+and a stale success reads as this run's. The pair only means anything if the second call
+describes the run the first one started.
+
 ### 8.4 The authoring skill
 
 A skill is needed for intent (and, at rung 4, trace) → generalised `Action`. Three kinds

--- a/doc/dev/platform-layer.md
+++ b/doc/dev/platform-layer.md
@@ -61,6 +61,11 @@ summary of the surface:
   find/enumerate/activate/geometry queries (`screen_frames`, `screen_work_frames`,
   `window_frames`); thread contract documented in
   [../configuration.md](../configuration.md#windows-screens-and-applications).
+- **`ImeProvider`** — `get_status()` (tri-state: on / off / `None` = could not
+  ask) and `set_status(on)`. Deliberately window-less: Windows reaches the state
+  through a window handle, macOS has only "the current input source", so a window
+  argument would split the contract between the two OSes. See
+  [../configuration.md](../configuration.md#ime).
 
 ## Windows implementation notes (`keyhac/platform/win/`, ctypes)
 
@@ -91,6 +96,14 @@ house style for raw-ctypes Win32/COM):
 - **Clipboard**: `AddClipboardFormatListener` on a message-only window →
   `WM_CLIPBOARDUPDATE` (event-driven; keyhac-win moved to this in 1.75). Text via
   `CF_UNICODETEXT`; optionally capture `CF_HTML`/`CF_DIB` payloads for history fidelity.
+- **IME**: `ImmGetDefaultIMEWnd(GetForegroundWindow())` → `WM_IME_CONTROL` with
+  `IMC_GETOPENSTATUS`/`IMC_SETOPENSTATUS` — the route pyauto used, and the only one
+  that crosses a process boundary (an `HIMC` is process-local). Sent with
+  `SendMessageTimeout(SMTO_NORMAL | SMTO_ABORTIFHUNG, 100 ms)`, **not**
+  `SendMessage`: this runs on the main thread inside the `WH_KEYBOARD_LL` callback,
+  and a hung target would stall the hook past `LowLevelHooksTimeout` (300 ms) and
+  get it silently unhooked. A TSF-only IME may not answer IMM32 at all, which is
+  what `None` reports.
 - **Caret**: `GetGUIThreadInfo().rcCaret` + `ClientToScreen` (balloon placement).
 - **Mouse**: `WH_MOUSE_LL` for one-shot cancellation on click
   (observation-only; own output recognized by dwExtraInfo); `SendInput` mouse
@@ -145,6 +158,18 @@ a few AX calls need `objc.loadBundleFunctions`-style care).
   would sit in the path of every pointer movement); mouse events are never
   consumed and never enter the key deferral queue, and own output is
   recognized by event source, mirroring the WH_MOUSE_LL rules.
+
+- **IME**: Text Input Sources (Carbon TIS), which PyObjC does not wrap — reached
+  by ctypes against `Carbon.framework`, as `keyboard_layout()` already does.
+  On/off is read off `kTISPropertyInputModeID` of the current source rather than
+  its bundle id, which is what makes it IME-agnostic: Kotoeri, Google IME and ATOK
+  all report `com.apple.inputmethod.Japanese*` / `.Roman`. Turning it *off* prefers
+  the current method's Roman mode but falls back to
+  `TISCopyCurrentASCIICapableKeyboardLayoutInputSource()`, because that Roman mode
+  is disabled on a default Japanese setup and `TISSelectInputSource` refuses a
+  disabled source with OSStatus −50 (measured, not assumed). CoreFoundation is
+  called through ctypes too, so ownership of the `+1` references the Copy/Create
+  functions return stays explicit.
 
 ## Keycode & layout strategy
 

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -169,6 +169,22 @@ macOS 15 on this machine). Highlights and the bugs the passes caught:
 - **macOS AX window tests**: 15 live tests (identity, enumeration, find_window,
   frame writes, minimize/restore, activate, worker-thread geometry), mirroring the
   Windows set.
+- **macOS IME** (2026-08-23, `tests/test_mac_ime.py`, Kotoeri installed): reading
+  the state off `kTISPropertyInputModeID` was verified against both ends
+  (`com.apple.keylayout.US` → off, `...RomajiTyping.Japanese` → on), and on/off
+  round-trips. The measurement that shaped the implementation: `TISSelectInputSource`
+  on the Roman mode fails with **OSStatus −50 (paramErr)** because that mode is
+  disabled on a default Japanese setup — hence the ASCII-capable-layout fallback,
+  which is also what the Eisu key reaches on such a setup. The probe also showed
+  the palette input sources (`CharacterPaletteIM`, `50onPaletteIM`, `PressAndHold`)
+  report no input mode, so the "first enabled non-Roman mode" selection cannot land
+  on one. The tests restore the input source they found.
+- **Windows IME**: `tests/test_win_ime.py` is written and **not yet run** — it needs
+  a machine with Microsoft IME, and it is the outstanding item for the IME API
+  (issue #107). What it has to establish beyond the round trip: that a TSF-only IME
+  answering nothing reads as `None` rather than `False`, and that the
+  `SendMessageTimeout` cap holds — a plain `SendMessage` here would stall the
+  `WH_KEYBOARD_LL` callback past `LowLevelHooksTimeout`.
 - **macOS element tree and text layer** (2026-08-06, Safari 18 / Chrome on a page
   built to the shape in `doc/dev/ai-integration.md` §2): `children()`,
   `describe()`, `get_ui_tree`, `find_element` by DOM id / label / role / text,
@@ -403,6 +419,12 @@ struck off.
   whenever that input-context code moves — which is exactly why 2.2.1 repeated
   it: that commit is what `puikit>=1.0.10` pins, and 2.2.1 is the first release
   taking it from the published wheel rather than a local checkout.
+- **The Windows JIS IME key names** *(new, not yet passed)* — that `Kanji`,
+  `Henkan` and `Muhenkan` actually match the 半角/全角, 変換 and 無変換 keys when
+  pressed on JIS hardware. The VKs (0x19 / 0x1C / 0x1D) are the documented ones,
+  but no JIS keyboard was available to confirm what the hardware really reports;
+  the console's last-key display is the one-line check. Same hardware dependency
+  as the entry below, so pass them together.
 - **JIS layout detection on real JIS hardware** *(passed 2026-08-07; **skipped
   for 2.2.1** — no JIS keyboard available)* — `GetKeyboardType(0) == 7`, one
   line. The tables it selects are pinned against `kbd106.dll` independently, so

--- a/keyhac/_config.py
+++ b/keyhac/_config.py
@@ -89,7 +89,9 @@ def configure(keymap):
     if mac:
         # The classic macOS setup: tap Left/Right Cmd alone for Eisu/Kana
         # (IME off/on) - a no-op unless a Japanese input source is
-        # installed.  Held, they are still plain Cmd.
+        # installed.  Held, they are still plain Cmd.  Both names work on
+        # Windows too (they reach VK_IME_OFF / VK_IME_ON there), so this
+        # pair is portable if you would rather bind it on both.
         kt["O-LCmd"] = "Eisu"
         kt["O-RCmd"] = "Kana"
     else:
@@ -116,6 +118,37 @@ def configure(keymap):
             ctx.send_key(f"{MOD}-C")
 
     kt[f"{LEADER}-Q"] = wrap_in_quotes
+
+    # ==================================================================
+    # IME
+    # ==================================================================
+
+    # Both calls act on whatever holds the input focus, and neither takes
+    # a window: macOS can only ever address the current input source, so a
+    # window argument would mean two different APIs wearing one name.
+    #
+    # get_ime_status() is tri-state - True, False, or None for "could not
+    # tell" (no IME installed, or on Windows a TSF-only IME that does not
+    # answer).  Treating None as False would silently claim the IME is off.
+    #
+    # For plain toggling, the Eisu / Kana key names above cost nothing and
+    # need no function at all; reach for these when you want the state.
+
+    def toggle_ime():
+        status = keymap.get_ime_status()
+        if status is None:
+            logger.warning("No IME to toggle.")
+            return
+        # set_ime_status() reads the state back, so False here means the
+        # IME declined - not that the call failed to go out.
+        if not keymap.set_ime_status(not status):
+            logger.warning("The IME did not take the change.")
+
+    kt[f"{LEADER}-Space"] = toggle_ime
+
+    # A sample of the state going the other way is in the terminal key
+    # table near the bottom: turning the IME off around a send_key()
+    # sequence, and putting it back the way it was.
 
     # ==================================================================
     # Clipboard
@@ -381,6 +414,29 @@ def configure(keymap):
 
     kt_terminal = keymap.define_keytable(custom_condition_func=is_terminal)
     kt_terminal[f"{LEADER}-K"] = "Ctrl-K"     # clear, rather than "Down"
+
+    # --- sending keys the IME must not eat -------------------------------
+    # send_key() feeds the IME exactly like real typing, so with a Japanese
+    # IME on this would compose instead of arriving.  send_text() and
+    # InputText() are unaffected - they inject the characters directly - so
+    # this dance is only ever needed when you are sending *keys*.
+    #
+    # `was_on` is tri-state, and falsy is the right reading of None: an IME
+    # we cannot see the state of is one to leave alone, in both directions.
+    def type_git_status():
+        was_on = keymap.get_ime_status()
+        if was_on:
+            keymap.set_ime_status(False)
+        try:
+            with keymap.get_input_context() as ctx:
+                for key in ("G", "I", "T", "Space",
+                            "S", "T", "A", "T", "U", "S"):
+                    ctx.send_key(key)
+        finally:
+            if was_on:
+                keymap.set_ime_status(True)
+
+    kt_terminal[f"{LEADER}-G"] = type_git_status
 
     # ==================================================================
     # More to explore

--- a/keyhac/core/action.py
+++ b/keyhac/core/action.py
@@ -192,13 +192,19 @@ class ThreadedAction:
             return self.run()
 
     @contextlib.contextmanager
-    def cancellable(self, name: str | None = None):
+    def cancellable(self, name: str | None = None, run=None):
         """Make this action reachable by Esc, and record what it produces.
 
         `name` is what the run is filed under. A caller that knows it - the
         MCP tool, which was handed a name to look the action up by - passes it
         rather than letting the lookup below go through the Keymap singleton,
         which is not necessarily the registry it came from.
+
+        `run` is for a caller that had to open the record *before* getting
+        here: `start_action` opens it on the calling thread so that the window
+        between it returning and this line running cannot be read as the
+        previous run of the same name. A key press passes neither and gets a
+        fresh record opened here.
 
         Both ways of starting an action enter this - `_run_tracked` for a key
         press, and the MCP tool that starts one from a chat window - which is
@@ -223,7 +229,8 @@ class ThreadedAction:
         # class's `module.Class` to look this up by. A key press has none to
         # give, so it is derived from the class, which lands on the same string
         # for anything defined in `extensions/`.
-        self._run_record = capture.start_run(name or self._run_name())
+        self._run_record = (run if run is not None
+                            else capture.start_run(name or self._run_name()))
         try:
             with capture.capture(self._run_record.output):
                 yield self

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -207,6 +207,7 @@ class Keymap:
         # Wired by main(): platform services + clipboard history + UI hooks
         self.app_control = None             # platform AppControl
         self.window_provider = None         # platform WindowProvider (may be None)
+        self.ime_provider = None            # platform ImeProvider (may be None)
         self._clipboard_history = None      # core ClipboardHistory
         self._mcp_server = None             # MCPServer while enabled
         self._mcp_timer = None              # closes the window on its own
@@ -1031,6 +1032,52 @@ class Keymap:
         if self.window_provider is None:
             return []
         return self.window_provider.window_frames()
+
+    # ------------------------------------------------------------------
+    # IME access (config-facing; see keyhac.platform.base.ImeProvider)
+
+    def get_ime_status(self) -> bool | None:
+        """Get whether the IME is on for whatever holds the input focus.
+
+        There is no window argument on purpose: macOS can only ever address
+        the current input source, so naming a window would mean two different
+        contracts on the two OSes.
+
+        Returns:
+            True when the IME is on, False when it is off, or None when the
+            state cannot be determined - no IME is installed or reachable, or
+            (Windows) a TSF-only IME does not answer the IMM32 query.
+
+        Note:
+            UI-thread only.  On macOS "off" means a plain keyboard layout or
+            an input method's Roman mode is selected, which is close to but
+            not the same thing as Windows' "the IME is closed".
+        """
+        if self.ime_provider is None:
+            return None
+        return self.ime_provider.get_status()
+
+    def set_ime_status(self, on: bool) -> bool:
+        """Turn the IME on or off for whatever holds the input focus.
+
+        Args:
+            on: True to turn the IME on, False to turn it off.
+
+        Returns:
+            Whether the requested state was actually reached - the result is
+            read back rather than assumed, so False means the IME declined or
+            there was none to ask.
+
+        Note:
+            UI-thread only.  Whether the change also affects other
+            applications is the user's OS setting ("Let me use a different
+            input method for each app window" on Windows, "Automatically
+            switch to a document's input source" on macOS), not something
+            Keyhac decides.
+        """
+        if self.ime_provider is None:
+            return False
+        return self.ime_provider.set_status(on)
 
     def app_control_running_apps(self):
         """[(app_name, pid)] via the platform (empty when unavailable).

--- a/keyhac/core/vk.py
+++ b/keyhac/core/vk.py
@@ -53,6 +53,11 @@ WIN_VK = dict(
     LBUTTON=0x01, RBUTTON=0x02, MBUTTON=0x04,
     BACK=0x08, TAB=0x09, RETURN=0x0D,
     SHIFT=0x10, CONTROL=0x11, MENU=0x12, PAUSE=0x13, CAPITAL=0x14,
+    # IME keys.  IME_ON/IME_OFF are what the portable Eisu/Kana names reach
+    # here: macOS's Eisu/Kana keys mean exactly "IME off"/"IME on", and a name
+    # is portable by meaning, not by scan code.  KANJI/CONVERT/NONCONVERT are
+    # the physical JIS keys, which macOS has no equivalent of.
+    IME_ON=0x16, KANJI=0x19, IME_OFF=0x1A, CONVERT=0x1C, NONCONVERT=0x1D,
     ESCAPE=0x1B, SPACE=0x20,
     PRIOR=0x21, NEXT=0x22, END=0x23, HOME=0x24,
     LEFT=0x25, UP=0x26, RIGHT=0x27, DOWN=0x28,
@@ -238,6 +243,8 @@ def _win_tables(layout: str):
         "APPS": v["APPS"],
         "INSERT": v["INSERT"], "DELETE": v["DELETE"], "HOME": v["HOME"],
         "END": v["END"], "PAGEDOWN": v["NEXT"], "PAGEUP": v["PRIOR"],
+        "EISU": v["IME_OFF"], "KANA": v["IME_ON"], "KANJI": v["KANJI"],
+        "HENKAN": v["CONVERT"], "MUHENKAN": v["NONCONVERT"],
         "ALT": v["MENU"], "LALT": v["LMENU"], "RALT": v["RMENU"],
         "CTRL": v["CONTROL"], "LCTRL": v["LCONTROL"], "RCTRL": v["RCONTROL"],
         "SHIFT": v["SHIFT"], "LSHIFT": v["LSHIFT"], "RSHIFT": v["RSHIFT"],
@@ -262,6 +269,8 @@ def _win_tables(layout: str):
         v["APPS"]: "Apps",
         v["INSERT"]: "Insert", v["DELETE"]: "Delete", v["HOME"]: "Home",
         v["END"]: "End", v["NEXT"]: "PageDown", v["PRIOR"]: "PageUp",
+        v["IME_OFF"]: "Eisu", v["IME_ON"]: "Kana", v["KANJI"]: "Kanji",
+        v["CONVERT"]: "Henkan", v["NONCONVERT"]: "Muhenkan",
         v["MENU"]: "Alt", v["LMENU"]: "LAlt", v["RMENU"]: "RAlt",
         v["CONTROL"]: "Ctrl", v["LCONTROL"]: "LCtrl", v["RCONTROL"]: "RCtrl",
         v["SHIFT"]: "Shift", v["LSHIFT"]: "LShift", v["RSHIFT"]: "RShift",

--- a/keyhac/main.py
+++ b/keyhac/main.py
@@ -107,16 +107,20 @@ def main() -> int:
         from keyhac.platform.mac.clipboard import MacClipboardProvider
         from keyhac.platform.mac.apps import MacAppControl
         from keyhac.platform.mac.window import MacWindowProvider
+        from keyhac.platform.mac.ime import MacImeProvider
         clipboard_provider = MacClipboardProvider()
         keymap.app_control = MacAppControl()
         keymap.window_provider = MacWindowProvider()
+        keymap.ime_provider = MacImeProvider()
     else:
         from keyhac.platform.win.clipboard import WinClipboardProvider
         from keyhac.platform.win.apps import WinAppControl
         from keyhac.platform.win.window import WinWindowProvider
+        from keyhac.platform.win.ime import WinImeProvider
         clipboard_provider = WinClipboardProvider()
         keymap.app_control = WinAppControl()
         keymap.window_provider = WinWindowProvider()
+        keymap.ime_provider = WinImeProvider()
     # The state files always sit beside the config, however it resolved: a
     # --config sandbox must not touch the real ~/.keyhac/clipboard.json, and a
     # portable install keeps its history on the stick with its config.

--- a/keyhac/mcp/tools.py
+++ b/keyhac/mcp/tools.py
@@ -728,14 +728,24 @@ class ToolRegistry:
             return (f"{name} is already running - get_action_result to watch "
                     f"it, or cancel_action to stop it.")
 
+        # Opened here, on the calling thread, and handed to the worker - not
+        # opened inside it. This call returns immediately by design, and a
+        # get_action_result arriving before the worker reached `cancellable`
+        # used to find the *previous* run of this name still on file: finished,
+        # so wait_for_run answered at once and the model read the last run's
+        # output as this one's. Which is the one failure the pair exists to
+        # prevent. It also makes the already-running guard above true for a
+        # second start_action inside that same window.
+        run = capture.start_run(name)
+
         # Always a ThreadedAction: that is what the scan matches on, and what
-        # instantiate() confirms. So `cancellable` opens the run record, files
-        # the traceback and closes it - the same path a key press takes, which
-        # is what makes a run started from here and one started by a key report
+        # instantiate() confirms. So `cancellable` files the traceback and
+        # closes the record - the same path a key press takes, which is what
+        # makes a run started from here and one started by a key report
         # identically.
         def body():
             try:
-                with action.cancellable(name):
+                with action.cancellable(name, run=run):
                     self.ui.on_main_thread(action.starting)
                     result = action.run()
                     self.ui.on_main_thread(lambda: action.finished(result))
@@ -744,7 +754,14 @@ class ToolRegistry:
                 # would only reach a daemon thread nobody is watching.
                 pass
 
-        threading.Thread(target=body, name=f"mcp-{name}", daemon=True).start()
+        try:
+            threading.Thread(target=body, name=f"mcp-{name}",
+                             daemon=True).start()
+        except BaseException as error:                    # noqa: BLE001
+            # A record left open would answer "still running" forever and the
+            # guard above would refuse every later start of this action.
+            run.finish("failed", f"the action's thread did not start: {error}")
+            raise
         return (f"{name} started. Call get_action_result to see what it did.")
 
     def get_action_result(self, name: str, wait: int = 30,

--- a/keyhac/platform/base.py
+++ b/keyhac/platform/base.py
@@ -233,6 +233,31 @@ class ClipboardProvider(ABC):
         """Return True when the clipboard changed since the last poll."""
 
 
+class ImeProvider(ABC):
+    """IME (input method) on/off state for whatever holds the input focus.
+
+    Deliberately window-less.  Windows reaches the state through a window
+    handle (IMM32 input contexts are per thread), so it *could* address a
+    background window; macOS has no such handle - TIS only ever exposes "the
+    current input source".  Naming a window would therefore split the contract
+    between the two OSes, so the portable one is the intersection: whatever has
+    the input focus right now.
+
+    Whether a change leaks to other applications is the user's OS setting
+    ("Let me use a different input method for each app window" on Windows,
+    "Automatically switch to a document's input source" on macOS), not
+    something this interface decides.
+    """
+
+    @abstractmethod
+    def get_status(self) -> bool | None:
+        """True when the IME is on, False when off, None when undeterminable."""
+
+    @abstractmethod
+    def set_status(self, on: bool) -> bool:
+        """Turn the IME on/off; return whether the state was actually reached."""
+
+
 class AppControl(ABC):
     """Application-level actions (activate, launch)."""
 

--- a/keyhac/platform/fake.py
+++ b/keyhac/platform/fake.py
@@ -1,12 +1,14 @@
 """Fake platform implementations for tests and headless development.
 
 FakeInputHook records injected events and lets tests drive the engine with
-scripted key sequences.  FakeFocusProvider returns a settable Focus.
+scripted key sequences.  FakeFocusProvider returns a settable Focus, and
+FakeImeProvider a settable IME state.
 """
 
 from typing import Callable, Sequence
 
-from keyhac.platform.base import InputHook, FocusProvider, Focus, KeyEvent
+from keyhac.platform.base import (InputHook, FocusProvider, Focus, KeyEvent,
+                                  ImeProvider)
 
 
 class FakeInputHook(InputHook):
@@ -97,3 +99,21 @@ class FakeFocusProvider(FocusProvider):
 
     def get_focus(self) -> Focus | None:
         return self.focus
+
+
+class FakeImeProvider(ImeProvider):
+    """Settable IME state.  ``status = None`` models the OS having no IME to
+    ask, and ``accepts`` an IME that declines the change."""
+
+    def __init__(self, status: bool | None = False, accepts: bool = True):
+        self.status = status
+        self.accepts = accepts
+
+    def get_status(self) -> bool | None:
+        return self.status
+
+    def set_status(self, on: bool) -> bool:
+        if not self.accepts or self.status is None:
+            return False
+        self.status = on
+        return True

--- a/keyhac/platform/mac/ime.py
+++ b/keyhac/platform/mac/ime.py
@@ -1,0 +1,217 @@
+"""macOS IME control - Text Input Sources (Carbon TIS) through ctypes.
+
+macOS has no notion of an IME being "open" the way Windows does; what it has
+is a selected *input source*, which for an input method carries an input mode
+(kTISPropertyInputModeID).  On/off is read off that mode:
+
+    com.apple.inputmethod.Japanese[.Katakana|.HalfWidthKana|.FullWidthRoman]
+        -> on           (and likewise a non-Roman mode of any other IME)
+    com.apple.inputmethod.Roman, or a plain keyboard layout with no mode
+        -> off
+
+Keying on the *mode* rather than the input source's bundle id is what makes
+this IME-agnostic: Kotoeri, Google IME and ATOK all report the same mode ids.
+
+TIS is not wrapped by PyObjC (neither Quartz nor ApplicationServices export
+it), so it is reached by ctypes against Carbon.framework - the same route
+MacInputHook.keyboard_layout() already takes.  CoreFoundation is called
+through ctypes too rather than bridging to PyObjC objects, so that ownership
+of the +1 references the Copy/Create functions return stays explicit.
+
+STATUS: get_status() verified live (read com.apple.keylayout.US as off and
+com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese as on).  set_status()'s
+Roman-mode fallback exists because selecting the Roman mode was measured to
+fail with OSStatus -50 (paramErr) when that mode is disabled, which it is by
+default when only "Japanese - Romaji" and a plain layout are enabled.
+"""
+
+import ctypes
+
+from keyhac.core import log
+from keyhac.platform.base import ImeProvider
+
+logger = log.getLogger("MacIme")
+
+#: Input mode of an input method sitting in its ASCII/alphanumeric state.
+ROMAN_MODE = "com.apple.inputmethod.Roman"
+
+_CF_PATH = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+_CARBON_PATH = "/System/Library/Frameworks/Carbon.framework/Carbon"
+
+_kCFStringEncodingUTF8 = 0x08000100
+
+
+class _TIS:
+    """The Carbon/CoreFoundation entry points, loaded once and prototyped.
+
+    Prototypes are declared in full for the same reason the Windows side does
+    it: the default c_int restype truncates a 64-bit pointer.
+    """
+
+    def __init__(self):
+        self.cf = ctypes.CDLL(_CF_PATH)
+        self.carbon = ctypes.CDLL(_CARBON_PATH)
+
+        void_p = ctypes.c_void_p
+        for lib, name, restype, argtypes in [
+            (self.cf, "CFRelease", None, [void_p]),
+            (self.cf, "CFArrayGetCount", ctypes.c_long, [void_p]),
+            (self.cf, "CFArrayGetValueAtIndex", void_p, [void_p, ctypes.c_long]),
+            (self.cf, "CFStringGetCString", ctypes.c_bool,
+             [void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32]),
+            (self.cf, "CFBooleanGetValue", ctypes.c_bool, [void_p]),
+            (self.carbon, "TISCopyCurrentKeyboardInputSource", void_p, []),
+            (self.carbon, "TISCopyCurrentASCIICapableKeyboardLayoutInputSource",
+             void_p, []),
+            (self.carbon, "TISCreateInputSourceList", void_p,
+             [void_p, ctypes.c_bool]),
+            (self.carbon, "TISGetInputSourceProperty", void_p, [void_p, void_p]),
+            (self.carbon, "TISSelectInputSource", ctypes.c_int32, [void_p]),
+        ]:
+            fn = getattr(lib, name)
+            fn.restype = restype
+            fn.argtypes = argtypes
+            setattr(self, name, fn)
+
+        # CFStringRef globals, resolved once.
+        self.key_mode_id = ctypes.c_void_p.in_dll(
+            self.carbon, "kTISPropertyInputModeID")
+        self.key_source_id = ctypes.c_void_p.in_dll(
+            self.carbon, "kTISPropertyInputSourceID")
+        self.key_enabled = ctypes.c_void_p.in_dll(
+            self.carbon, "kTISPropertyInputSourceIsEnabled")
+        self.key_select_capable = ctypes.c_void_p.in_dll(
+            self.carbon, "kTISPropertyInputSourceIsSelectCapable")
+
+    def cfstring(self, ref) -> str | None:
+        """Copy a CFStringRef out as a Python str."""
+        if not ref:
+            return None
+        buf = ctypes.create_string_buffer(512)
+        if not self.CFStringGetCString(ref, buf, len(buf), _kCFStringEncodingUTF8):
+            return None
+        return buf.value.decode("utf-8", "replace")
+
+    def property_string(self, source, key) -> str | None:
+        """A source's string property (the ref is borrowed - do not release)."""
+        return self.cfstring(self.TISGetInputSourceProperty(source, key))
+
+    def property_bool(self, source, key) -> bool:
+        ref = self.TISGetInputSourceProperty(source, key)
+        return bool(ref) and bool(self.CFBooleanGetValue(ref))
+
+
+_tis = None
+_tis_failed = False
+
+
+def _tis_api() -> "_TIS | None":
+    """The loaded TIS entry points, or None if the frameworks are unreachable
+    (logged once, then remembered so a broken load is not retried per key)."""
+    global _tis, _tis_failed
+    if _tis is None and not _tis_failed:
+        try:
+            _tis = _TIS()
+        except Exception as e:
+            _tis_failed = True
+            logger.error(f"Text Input Sources unavailable: {e}")
+    return _tis
+
+
+def _mode_is_on(mode_id: str | None) -> bool:
+    """Whether an input mode counts as "IME on"."""
+    # No mode at all means a plain keyboard layout is selected, not an IME.
+    return bool(mode_id) and mode_id != ROMAN_MODE
+
+
+class MacImeProvider(ImeProvider):
+    """IME on/off via the current Text Input Source."""
+
+    def get_status(self) -> bool | None:
+        api = _tis_api()
+        if api is None:
+            return None
+        source = api.TISCopyCurrentKeyboardInputSource()
+        if not source:
+            logger.debug("No current keyboard input source.")
+            return None
+        try:
+            return _mode_is_on(api.property_string(source, api.key_mode_id))
+        finally:
+            api.CFRelease(source)
+
+    def set_status(self, on: bool) -> bool:
+        api = _tis_api()
+        if api is None:
+            return False
+        # Already there: nothing to select.  Not just an optimization - the
+        # selection below picks the *first* enabled mode, so re-asserting "on"
+        # while the user sits in Katakana would drag them back to Hiragana.
+        # (The Windows side needs no such guard: IMC_SETOPENSTATUS to the value
+        # already held is a true no-op, and skipping it would only buy an extra
+        # cross-process round trip.)
+        if self.get_status() is on:
+            return True
+        if on:
+            ok = self._select_input_mode(api, want_roman=False)
+        else:
+            # Preferred: the current method's Roman mode, which keeps the same
+            # input source selected and only flips it to alphanumeric.  That
+            # mode is disabled on a default Japanese setup, though, and
+            # TISSelectInputSource refuses a disabled source (OSStatus -50), so
+            # fall back to the ASCII-capable layout - which is what the Eisu
+            # key reaches on such a setup anyway.
+            ok = (self._select_input_mode(api, want_roman=True)
+                  or self._select_ascii_layout(api))
+        if not ok:
+            return False
+        # Report what was actually reached rather than that a call returned 0.
+        return self.get_status() is on
+
+    # ------------------------------------------------------------------
+
+    def _select(self, api, source) -> bool:
+        err = api.TISSelectInputSource(source)
+        if err != 0:
+            logger.debug(f"TISSelectInputSource failed with OSStatus {err}.")
+            return False
+        return True
+
+    def _select_input_mode(self, api, want_roman: bool) -> bool:
+        """Select the first enabled input mode on the wanted side of Roman.
+
+        "First enabled" is as good as it gets with several IMEs installed: TIS
+        exposes no most-recently-used order, and there is no way to ask what
+        the Kana key itself would pick.  set_status() not disturbing an IME
+        that is already on is what keeps that from mattering in practice.
+        """
+        sources = api.TISCreateInputSourceList(None, False)
+        if not sources:
+            return False
+        try:
+            for i in range(api.CFArrayGetCount(sources)):
+                source = api.CFArrayGetValueAtIndex(sources, i)
+                mode_id = api.property_string(source, api.key_mode_id)
+                if mode_id is None:
+                    continue
+                if (mode_id == ROMAN_MODE) is not want_roman:
+                    continue
+                if not api.property_bool(source, api.key_select_capable):
+                    continue
+                if not api.property_bool(source, api.key_enabled):
+                    continue
+                if self._select(api, source):
+                    return True
+            return False
+        finally:
+            api.CFRelease(sources)
+
+    def _select_ascii_layout(self, api) -> bool:
+        source = api.TISCopyCurrentASCIICapableKeyboardLayoutInputSource()
+        if not source:
+            logger.debug("No ASCII-capable keyboard layout to fall back to.")
+            return False
+        try:
+            return self._select(api, source)
+        finally:
+            api.CFRelease(source)

--- a/keyhac/platform/win/ime.py
+++ b/keyhac/platform/win/ime.py
@@ -1,0 +1,108 @@
+"""Windows IME control - IMM32 through the foreground window's IME window.
+
+The IME open/close state lives in an input context, which by default belongs
+to a thread and is shared by that thread's windows.  A context in another
+process is not reachable through ImmGetOpenStatus (the HIMC is process-local),
+so the way in is the one pyauto used: ask the target thread's hidden IME
+window, which ImmGetDefaultIMEWnd() hands back, over WM_IME_CONTROL.
+
+Two things make that message send worth care:
+
+- It is a *cross-process synchronous* send, and this runs on the main thread,
+  i.e. inside the WH_KEYBOARD_LL callback when a key action triggers it.  A
+  plain SendMessage into a hung or non-pumping target would stall the hook past
+  LowLevelHooksTimeout (300 ms by default) and Windows would silently unhook
+  it.  Hence SendMessageTimeout with a short cap and SMTO_ABORTIFHUNG; the
+  SMTO_NORMAL half lets this thread keep servicing incoming sends meanwhile,
+  so a target that is itself waiting on us cannot deadlock.
+- IMM32 is answered by IMEs that keep an IMM32 compatibility surface, which
+  Microsoft IME does.  A TSF-only IME may not answer at all - that is what
+  get_status() returning None means, and why it is not folded into False.
+
+STATUS: written to spec; needs a live Windows pass with Microsoft IME (see
+doc/dev/testing.md).
+"""
+
+import ctypes
+import sys
+
+from keyhac.core import log
+from keyhac.platform.base import ImeProvider
+
+logger = log.getLogger("WinIme")
+
+#: Cap on the cross-process send.  Well under LowLevelHooksTimeout's 300 ms
+#: default, since the whole budget is spent inside the hook callback.
+SEND_TIMEOUT_MS = 100
+
+if sys.platform == "win32":
+    from ctypes import wintypes
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    imm32 = ctypes.WinDLL("imm32", use_last_error=True)
+
+    # wintypes has no LRESULT/DWORD_PTR; both are pointer-sized, and LPARAM
+    # already is (same reasoning as hook.py).  Mandatory on 64-bit: the
+    # default c_int restype would truncate the HWNDs below.
+    LRESULT = wintypes.LPARAM
+    DWORD_PTR = wintypes.WPARAM
+
+    WM_IME_CONTROL = 0x0283
+    IMC_GETOPENSTATUS = 0x0005
+    IMC_SETOPENSTATUS = 0x0006
+
+    SMTO_NORMAL = 0x0000
+    SMTO_ABORTIFHUNG = 0x0002
+
+    user32.GetForegroundWindow.argtypes = []
+    user32.GetForegroundWindow.restype = wintypes.HWND
+    user32.SendMessageTimeoutW.argtypes = [
+        wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM,
+        wintypes.UINT, wintypes.UINT, ctypes.POINTER(DWORD_PTR)]
+    user32.SendMessageTimeoutW.restype = LRESULT
+    imm32.ImmGetDefaultIMEWnd.argtypes = [wintypes.HWND]
+    imm32.ImmGetDefaultIMEWnd.restype = wintypes.HWND
+
+
+class WinImeProvider(ImeProvider):
+    """IME on/off of the foreground window's input context."""
+
+    def get_status(self) -> bool | None:
+        result = self._ime_control(IMC_GETOPENSTATUS, 0)
+        return None if result is None else bool(result)
+
+    def set_status(self, on: bool) -> bool:
+        if self._ime_control(IMC_SETOPENSTATUS, 1 if on else 0) is None:
+            return False
+        # Report what was actually reached: an IME may decline the change
+        # (no conversion mode available for the current input language).
+        return self.get_status() is on
+
+    # ------------------------------------------------------------------
+
+    def _ime_control(self, command: int, value: int) -> int | None:
+        """Send one WM_IME_CONTROL to the foreground window's IME window.
+
+        Returns the message result, or None when there is nothing to ask -
+        no foreground window, no IME for its thread, or the send timed out.
+        """
+        hwnd = user32.GetForegroundWindow()
+        if not hwnd:
+            logger.debug("No foreground window to reach an IME through.")
+            return None
+        ime_hwnd = imm32.ImmGetDefaultIMEWnd(hwnd)
+        if not ime_hwnd:
+            logger.debug("The foreground window's thread has no IME window.")
+            return None
+
+        result = DWORD_PTR()
+        sent = user32.SendMessageTimeoutW(
+            ime_hwnd, WM_IME_CONTROL, command, value,
+            SMTO_NORMAL | SMTO_ABORTIFHUNG, SEND_TIMEOUT_MS,
+            ctypes.byref(result))
+        if not sent:
+            logger.debug(f"WM_IME_CONTROL {command:#x} got no answer within "
+                         f"{SEND_TIMEOUT_MS} ms (error "
+                         f"{ctypes.get_last_error()}).")
+            return None
+        return result.value

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -95,3 +95,51 @@ def test_a_named_terminal_still_matches(shipped):
     assert any(condition.check(terminal)
                for condition in custom_conditions(shipped)), \
         "no sample condition recognises Terminal any more"
+
+
+def shipped_action(keymap, name):
+    """The template's binding whose function has this name, wherever it sits."""
+    for table in keymap._all_keytables:
+        for action in table.table.values():
+            if getattr(action, "__name__", None) == name:
+                return action
+    raise AssertionError(f"the template no longer binds {name}()")
+
+
+def test_the_ime_samples_run(shipped):
+    """The IME samples read a tri-state and drive an input context; only
+    running them says whether they still line up with the API."""
+    from keyhac.platform.fake import FakeImeProvider
+
+    shipped.ime_provider = FakeImeProvider(status=False)
+    toggle = shipped_action(shipped, "toggle_ime")
+
+    toggle()
+    assert shipped.get_ime_status() is True
+    toggle()
+    assert shipped.get_ime_status() is False
+
+
+def test_the_ime_sample_restores_the_state_it_found(shipped):
+    from keyhac.platform.fake import FakeImeProvider
+
+    shipped.ime_provider = FakeImeProvider(status=True)
+    type_git_status = shipped_action(shipped, "type_git_status")
+
+    type_git_status()
+    assert shipped.get_ime_status() is True, "the IME was left off"
+    assert shipped._hook.sent, "no keys reached the hook"
+
+
+def test_the_ime_samples_leave_an_unreadable_ime_alone(shipped, caplog):
+    """None means "could not tell"; neither sample may act on it."""
+    from keyhac.platform.fake import FakeImeProvider
+
+    shipped.ime_provider = FakeImeProvider(status=None)
+
+    with caplog.at_level("WARNING"):
+        shipped_action(shipped, "toggle_ime")()
+    assert "No IME to toggle" in caplog.text
+
+    shipped_action(shipped, "type_git_status")()
+    assert shipped.get_ime_status() is None

--- a/tests/test_ime.py
+++ b/tests/test_ime.py
@@ -1,0 +1,97 @@
+"""The portable IME API: Keymap.get_ime_status / set_ime_status.
+
+The interesting part of this API is what it promises when the OS cannot
+answer, so most of these pin the None / False paths rather than the happy one.
+The live per-OS behavior is in test_mac_ime.py and test_win_ime.py.
+"""
+
+import pytest
+
+from keyhac.core.vk import init_key_names
+from keyhac.platform.fake import FakeImeProvider
+
+
+def configure_nothing(keymap):
+    pass
+
+
+@pytest.fixture
+def keymap(engine):
+    km = engine(configure_nothing).keymap
+    km.ime_provider = FakeImeProvider()
+    return km
+
+
+# -- the Keymap surface -------------------------------------------------
+
+def test_status_round_trip(keymap):
+    assert keymap.get_ime_status() is False
+    assert keymap.set_ime_status(True) is True
+    assert keymap.get_ime_status() is True
+    assert keymap.set_ime_status(False) is True
+    assert keymap.get_ime_status() is False
+
+
+def test_no_provider_reads_none_and_writes_false(engine):
+    km = engine(configure_nothing).keymap
+    assert km.ime_provider is None
+    assert km.get_ime_status() is None
+    assert km.set_ime_status(True) is False
+
+
+def test_undeterminable_state_is_none_not_false(keymap):
+    """None means "could not ask", which False would silently misreport."""
+    keymap.ime_provider.status = None
+    assert keymap.get_ime_status() is None
+    assert keymap.set_ime_status(True) is False
+
+
+def test_a_declined_change_reports_false(keymap):
+    keymap.ime_provider.accepts = False
+    assert keymap.set_ime_status(True) is False
+    assert keymap.get_ime_status() is False
+
+
+# -- macOS: mapping an input mode onto on/off ---------------------------
+
+def test_mac_input_mode_maps_to_on_off():
+    from keyhac.platform.mac.ime import _mode_is_on, ROMAN_MODE
+
+    # A Japanese method in any of its kana modes is on ...
+    for mode in ["com.apple.inputmethod.Japanese",
+                 "com.apple.inputmethod.Japanese.Katakana",
+                 "com.apple.inputmethod.Japanese.HalfWidthKana",
+                 "com.apple.inputmethod.Japanese.FullWidthRoman"]:
+        assert _mode_is_on(mode) is True, mode
+    # ... and so is any other IME's non-Roman mode (the check is on the mode,
+    # not on the bundle, which is what makes it work beyond Kotoeri).
+    assert _mode_is_on("com.apple.inputmethod.SCIM.ITABC") is True
+    # Alphanumeric mode, and a plain keyboard layout (no mode at all), are off.
+    assert _mode_is_on(ROMAN_MODE) is False
+    assert _mode_is_on(None) is False
+
+
+# -- the key names the two OSes reach ------------------------------------
+
+def test_eisu_and_kana_are_portable_by_meaning():
+    """Same names on both OSes, different codes - Windows reaches VK_IME_OFF /
+    VK_IME_ON, which is what macOS's Eisu / Kana keys mean."""
+    mac = init_key_names("mac", "jis")
+    win = init_key_names("windows", "jis")
+    assert (mac.str_to_vk("Eisu"), mac.str_to_vk("Kana")) == (0x66, 0x68)
+    assert (win.str_to_vk("Eisu"), win.str_to_vk("Kana")) == (0x1A, 0x16)
+    for names in (mac, win):
+        assert names.vk_to_str(names.str_to_vk("Eisu")) == "Eisu"
+        assert names.vk_to_str(names.str_to_vk("Kana")) == "Kana"
+
+
+def test_physical_jis_keys_are_windows_only():
+    win = init_key_names("windows", "jis")
+    assert win.str_to_vk("Kanji") == 0x19
+    assert win.str_to_vk("Henkan") == 0x1C
+    assert win.str_to_vk("Muhenkan") == 0x1D
+
+    mac = init_key_names("mac", "jis")
+    for name in ("Kanji", "Henkan", "Muhenkan"):
+        with pytest.raises(ValueError, match="only on Windows"):
+            mac.str_to_vk(name)

--- a/tests/test_mac_ime.py
+++ b/tests/test_mac_ime.py
@@ -1,0 +1,108 @@
+"""macOS IME provider - live against the real Text Input Sources.
+
+These change the process-wide input source, so the module fixture snapshots
+the selected one and puts it back afterwards.  Skipped when the machine has no
+input method installed (a plain-keyboard-layout Mac has no IME to turn on),
+which is what CI sees.
+"""
+
+import sys
+
+import pytest
+
+if sys.platform != "darwin":
+    pytest.skip("macOS-only platform layer", allow_module_level=True)
+
+from keyhac.platform.mac.ime import MacImeProvider, _tis_api  # noqa: E402
+
+
+def _current_source_id(api):
+    source = api.TISCopyCurrentKeyboardInputSource()
+    if not source:
+        return None
+    try:
+        return api.property_string(source, api.key_source_id)
+    finally:
+        api.CFRelease(source)
+
+
+def _select_source_id(api, source_id) -> bool:
+    sources = api.TISCreateInputSourceList(None, False)
+    try:
+        for i in range(api.CFArrayGetCount(sources)):
+            source = api.CFArrayGetValueAtIndex(sources, i)
+            if api.property_string(source, api.key_source_id) == source_id:
+                return api.TISSelectInputSource(source) == 0
+        return False
+    finally:
+        api.CFRelease(sources)
+
+
+def _has_input_method(api) -> bool:
+    sources = api.TISCreateInputSourceList(None, False)
+    try:
+        return any(
+            api.property_string(api.CFArrayGetValueAtIndex(sources, i),
+                                api.key_mode_id) is not None
+            for i in range(api.CFArrayGetCount(sources)))
+    finally:
+        api.CFRelease(sources)
+
+
+@pytest.fixture(scope="module")
+def provider():
+    api = _tis_api()
+    if api is None:
+        pytest.skip("Text Input Sources unavailable")
+    if not _has_input_method(api):
+        pytest.skip("no input method installed to switch on")
+    saved = _current_source_id(api)
+    yield MacImeProvider()
+    if saved:
+        _select_source_id(api, saved)
+
+
+def test_status_is_a_bool_not_none(provider):
+    """A Mac with an input method can always answer; None is for the case
+    where TIS itself is unreachable."""
+    assert provider.get_status() in (True, False)
+
+
+def test_turning_on_and_off_round_trips(provider):
+    assert provider.set_status(True) is True
+    assert provider.get_status() is True
+    assert provider.set_status(False) is True
+    assert provider.get_status() is False
+    assert provider.set_status(True) is True
+    assert provider.get_status() is True
+
+
+def test_setting_the_state_it_is_already_in_succeeds(provider):
+    provider.set_status(False)
+    assert provider.set_status(False) is True
+    assert provider.get_status() is False
+
+
+def test_off_never_lands_on_an_input_method(provider):
+    """Off must reach a plain layout or a Roman mode - the fallback exists
+    because the Roman mode is disabled on a default Japanese setup, and
+    TISSelectInputSource refuses a disabled source (OSStatus -50)."""
+    api = _tis_api()
+    provider.set_status(True)
+    assert provider.set_status(False) is True
+    source = api.TISCopyCurrentKeyboardInputSource()
+    try:
+        mode = api.property_string(source, api.key_mode_id)
+    finally:
+        api.CFRelease(source)
+    assert mode is None or mode == "com.apple.inputmethod.Roman"
+
+
+def test_turning_on_while_already_on_keeps_the_selected_mode(provider):
+    """"On" must not mean "the first enabled mode": re-asserting it while the
+    user sits in, say, Katakana would drag them back to Hiragana."""
+    api = _tis_api()
+    provider.set_status(True)
+    before = _current_source_id(api)
+    assert provider.set_status(True) is True
+    assert _current_source_id(api) == before

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2132,3 +2132,34 @@ def test_the_call_log_does_not_land_in_a_running_action(writable):
     assert "[keyhac.MCP]" not in peek
     gate.set()
     writable.call("get_action_result", {"name": "slow.Slow", "wait": 20})
+
+
+def test_start_action_files_the_run_before_it_returns(writable, monkeypatch):
+    """The window between start_action returning and its worker opening the
+    run record used to read as the *previous* run of the same name: finished,
+    so get_action_result answered at once with the last run's output as this
+    one's.  A model polling `did it work?` got yes from the run before.
+
+    The worker is stopped from ever starting, so everything below has to have
+    happened in start_action itself - which is exactly the window.
+    """
+    assert "the first run" in _register(
+        writable, lambda: print("the first run"), name="race")
+    finished = capture.get_run("race.Probe")
+
+    monkeypatch.setattr(threading.Thread, "start", lambda self: None)
+    sys.modules["race"].RUN = lambda: print("the second run")
+    writable.call("start_action", {"name": "race.Probe"})
+
+    run = capture.get_run("race.Probe")
+    try:
+        assert run is not finished, "start_action left the previous run on file"
+        assert run.running
+        # And the guard that stops a double start now covers the window too.
+        assert "already running" in writable.call(
+            "start_action", {"name": "race.Probe"})
+        assert "the first run" not in writable.call(
+            "get_action_result", {"name": "race.Probe", "wait": 0})
+    finally:
+        # Nothing else will: this run has no worker to close it.
+        run.finish("cancelled", "the test never let the worker start")

--- a/tests/test_win_ime.py
+++ b/tests/test_win_ime.py
@@ -1,0 +1,64 @@
+"""Windows IME provider - live against the real IMM32 state.
+
+Needs an IME installed for the current input language (Microsoft IME); the
+whole module skips otherwise, since a machine with no IME can only ever answer
+None.  The state read and written is the foreground window's - i.e. whatever
+console pytest is running in - and the fixture puts it back afterwards.
+
+STATUS: written to spec; run this on the Windows pass (doc/dev/testing.md).
+"""
+
+import sys
+
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("Windows-only platform layer", allow_module_level=True)
+
+from keyhac.platform.win.ime import WinImeProvider  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def provider():
+    provider = WinImeProvider()
+    saved = provider.get_status()
+    if saved is None:
+        pytest.skip("no IME answers IMM32 for the foreground window")
+    yield provider
+    provider.set_status(saved)
+
+
+def test_status_is_a_bool_when_an_ime_answers(provider):
+    assert provider.get_status() in (True, False)
+
+
+def test_turning_on_and_off_round_trips(provider):
+    assert provider.set_status(True) is True
+    assert provider.get_status() is True
+    assert provider.set_status(False) is True
+    assert provider.get_status() is False
+
+
+def test_setting_the_state_it_is_already_in_succeeds(provider):
+    provider.set_status(False)
+    assert provider.set_status(False) is True
+    assert provider.get_status() is False
+
+
+def test_the_send_is_capped_well_under_the_hook_timeout():
+    """The cap is load-bearing: this runs inside the WH_KEYBOARD_LL callback,
+    and exceeding LowLevelHooksTimeout (300 ms) gets the hook silently
+    unhooked."""
+    from keyhac.platform.win import ime
+    assert ime.SEND_TIMEOUT_MS <= 150
+
+
+def test_a_query_returns_promptly(provider):
+    """A responsive IME answers far inside the cap; this is the regression
+    guard for accidentally reintroducing a blocking SendMessage."""
+    import time
+    start = time.perf_counter()
+    for _ in range(10):
+        provider.get_status()
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert elapsed_ms < 10 * 50


### PR DESCRIPTION
Closes #107.

`keymap.get_ime_status()` / `set_ime_status()`, one API over IMM32 on Windows and the input-source APIs on macOS, plus the config-facing documentation and a sample in the template.

### The four commits

- **Keyhac gains a portable IME on/off API** — the API, both platform implementations, and the tests.
- **start_action opens the run record before it returns** — a bug the IME work surfaced rather than caused: `get_action_result` called right after `start_action` could be answered out of the *previous* run of the same name, because the record was opened inside the spawned thread. The record is now opened on the calling thread and handed to the worker.
- **The Windows IME pass corrects what the API was asking** — `tests/test_win_ime.py` had been written to spec and never run. Running it against ground truth (driving the IME with the OS's own `VK_IME_ON`/`VK_IME_OFF` and reading back what a real control receives) found two bugs: the foreground window is the wrong window to ask (`GetGUIThreadInfo(...).hwndFocus` carries the live state, the frame does not), and an open status under a layout with no IME is a phantom, so both calls are now gated on `ImmGetProperty(hkl, IGP_CONVERSION)`.
- **The IME sample was racing its own keystrokes** — reported from a live config: `set_ime_status()` takes effect at once while `send_key()` only queues, so a restore in a `finally` landed while the keys were still in flight. The sample goes; `send_text()` never needed the dance. `InputContext` and `set_ime_status()` now document that the batch is queued rather than delivered, which is what made the broken shape writable in the first place.

### State

Live-verified on Windows with both languages installed and with only Japanese (the plain-layout half skips by design), and swept by hand across Notepad, Edge/Chromium and a PuiKit window. Still uncovered: a TSF-only IME answering nothing, and the JIS key names, which need hardware this machine does not have.

Merges cleanly onto current main; the full suite passes on the merged tree (601 passed) and `make api-reference-check` is in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)