### PR TITLE
The Windows IME pass, and the sample that raced its own keystrokes

### DIFF
--- a/doc/config-api.md
+++ b/doc/config-api.md
@@ -263,7 +263,7 @@ There is no window argument on purpose: macOS can only ever address the current 
 
 **Note:**
 
-> UI-thread only.  On macOS "off" means a plain keyboard layout or an input method's Roman mode is selected, which is close to but not the same thing as Windows' "the IME is closed". 
+> UI-thread only.  "Off" is the same answer for two different situations, on both OSes: an IME that is installed and closed, and no IME in the picture at all - a plain keyboard layout on Windows, a plain layout or an input method's Roman mode on macOS. 
 
 ---
 
@@ -425,7 +425,8 @@ Turn the IME on or off for whatever holds the input focus.
 
 **Note:**
 
-> UI-thread only.  Whether the change also affects other applications is the user's OS setting ("Let me use a different input method for each app window" on Windows, "Automatically switch to a document's input source" on macOS), not something Keyhac decides. 
+> UI-thread only.  The two OSes differ in how far "on" reaches: macOS selects a Japanese input source even from a US layout, while Windows only opens an IME that the focused window is already typing under - asking for "on" while a plain layout like en-US is active returns False rather than switching the input language, which is the user's own Win+Space to give. 
+>Whether a change also affects other applications is the user's OS setting ("Let me use a different input method for each app window" on Windows, "Automatically switch to a document's input source" on macOS), not something Keyhac decides. 
 
 ---
 

--- a/doc/config-api.md
+++ b/doc/config-api.md
@@ -425,7 +425,8 @@ Turn the IME on or off for whatever holds the input focus.
 
 **Note:**
 
-> UI-thread only.  The two OSes differ in how far "on" reaches: macOS selects a Japanese input source even from a US layout, while Windows only opens an IME that the focused window is already typing under - asking for "on" while a plain layout like en-US is active returns False rather than switching the input language, which is the user's own Win+Space to give. 
+> UI-thread only, and it takes effect **at once** - unlike key output, which `InputContext` only queues for the application. Wrapping a `send_key` batch in "off ... back on" therefore does not work: the restore lands before the keys do and they are composed anyway.  Use `InputContext.send_text` for literal text, which the IME does not intercept. 
+>The two OSes differ in how far "on" reaches: macOS selects a Japanese input source even from a US layout, while Windows only opens an IME that the focused window is already typing under - asking for "on" while a plain layout like en-US is active returns False rather than switching the input language, which is the user's own Win+Space to give. 
 >Whether a change also affects other applications is the user's OS setting ("Let me use a different input method for each app window" on Windows, "Automatically switch to a document's input source" on macOS), not something Keyhac decides. 
 
 ---
@@ -565,6 +566,8 @@ Build a focus condition.
 A context manager to send virtual key strokes. 
 
 Key events are accumulated and sent as one batch when the context exits. Physically held modifiers are released around the batch and restored afterwards, so ``ctx.send_key("Ctrl-C")`` works even while the modifiers of the binding that triggered it are still down. 
+
+Sending is where the batch *ends*, not where it arrives: the events are queued for the application to pick up later.  So anything the action does after the context exits - changing the IME state, activating another window - takes effect while the keys are still in flight, and lands first.  ``keymap.set_ime_status(False)`` around a ``send_key`` batch is the trap this makes: the matching restore wins the race and the keys are composed by the IME after all.  Send literal text with ``send_text()``, which the IME does not intercept, and leave IME changes standing rather than undoing them in the same action. 
 
 ``keymap.get_input_context()`` creates one.  It is safe to use from a ThreadedAction worker thread. 
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -277,6 +277,15 @@ Some caveats worth knowing:
   "Let me use a different input method for each app window" on Windows,
   "Automatically switch to a document's input source" on macOS — not something
   Keyhac decides.
+- **Do not wrap key output in "off … back on".** The state change takes effect at
+  once, while `send_key()` only *queues* its events for the application to pick up
+  later — so the restore lands first and the keys compose anyway (`"git status"`
+  arrives as `"gいt"`). Waiting it out is not the fix either: a key-triggered
+  action runs on the main thread inside the keyboard hook, where sleeping past the
+  hook timeout gets the hook unhooked. For literal text use `ctx.send_text()` or
+  `InputText`, which inject the characters themselves and are unaffected by the
+  IME. If keys must go out with the IME closed, close it and leave it closed — the
+  `Kana` / 半角全角 key is how the user puts it back.
 
 For simply toggling, the key names cost nothing and work on both OSes: `Eisu` is
 IME off and `Kana` is IME on, reaching the macOS keys of those names and Windows'

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -258,11 +258,17 @@ determined: no IME is installed, or on Windows a TSF-only IME that does not answ
 the IMM32 query. `set_ime_status()` reads the state back rather than assuming the
 call took, so its `False` means the IME declined or there was none to ask.
 
-Two caveats worth knowing:
+Some caveats worth knowing:
 
-- On macOS, "off" means a plain keyboard layout or an input method's Roman mode is
-  selected. That is close to, but not the same thing as, Windows' "the IME is
-  closed".
+- "Off" covers two different situations on both OSes: an IME that is installed and
+  closed, and no IME in the picture at all — a plain keyboard layout on Windows, a
+  plain layout or an input method's Roman mode on macOS.
+- **"On" does not reach as far on Windows as on macOS.** macOS selects a Japanese
+  input source even from a US layout; Windows only opens an IME the focused window
+  is *already* typing under, so `set_ime_status(True)` under en-US returns `False`
+  instead of switching the input language. Switching languages stays the user's own
+  Win+Space. A portable config should therefore treat `False` as "the user is not
+  in an IME language right now", not as a failure worth retrying.
 - Turning the IME *on* when it already is leaves the current mode alone, so a
   binding that asserts "on" will not drag a macOS user out of Katakana back into
   Hiragana. With several IMEs installed and the IME off, which one "on" picks is

--- a/doc/dev/design-notes.md
+++ b/doc/dev/design-notes.md
@@ -214,6 +214,33 @@ before running it.
   Python must not sit in the path of every pointer move). Own output is recognized
   via `dwExtraInfo` / event source and ignored.
 
+## IME on/off
+
+- The two OSes model this at different depths, and the API deliberately stops at
+  the shallower one. macOS has **one** level — the selected input source — so
+  "on" there means *selecting* a Japanese input source, reachable even from a US
+  layout. Windows has **two** — the thread's layout/TIP, and the IME's open status
+  inside it — and `set_ime_status()` only drives the second. Asking for "on" while
+  a plain layout like en-US is active therefore returns `False` instead of
+  switching the input language.
+- That is a decision, not a gap. Switching the input language is user-visible and
+  as heavy as the user's own Win+Space; it is not undone by the matching "off"
+  (which closes the IME and leaves the language switched), so a symmetric
+  implementation would have to remember and restore the previous `HKL`. Both were
+  measured on Windows 11 — the language switch does work through
+  `WM_INPUTLANGCHANGEREQUEST` posted to the *focused* window, so this is a choice
+  about scope rather than about what is possible.
+- The asymmetry only reaches users who run an IME language **and** a non-IME one.
+  On a Japanese-only setup — the classic one, where 半角/全角 opens and closes the
+  only installed IME — every layout satisfies the gate, the two levels collapse
+  into one, and the two OSes behave the same. `tests/test_win_ime.py` accounts for
+  that configuration: its plain-layout half skips when every installed layout has
+  an IME behind it.
+- Two Windows-only outcomes survive any language configuration: a window that has
+  no input context at all (PuiKit's own windows until a text field wants one) can
+  never be turned on, and a TSF-only IME that does not answer IMM32 is the one
+  path to `None`.
+
 ## Data directory and Windows portable mode
 
 `keyhac/core/paths.py` is the single place that decides where `config.py` and the

--- a/doc/dev/platform-layer.md
+++ b/doc/dev/platform-layer.md
@@ -96,9 +96,21 @@ house style for raw-ctypes Win32/COM):
 - **Clipboard**: `AddClipboardFormatListener` on a message-only window →
   `WM_CLIPBOARDUPDATE` (event-driven; keyhac-win moved to this in 1.75). Text via
   `CF_UNICODETEXT`; optionally capture `CF_HTML`/`CF_DIB` payloads for history fidelity.
-- **IME**: `ImmGetDefaultIMEWnd(GetForegroundWindow())` → `WM_IME_CONTROL` with
+- **IME**: `ImmGetDefaultIMEWnd(focused window)` → `WM_IME_CONTROL` with
   `IMC_GETOPENSTATUS`/`IMC_SETOPENSTATUS` — the route pyauto used, and the only one
-  that crosses a process boundary (an `HIMC` is process-local). Sent with
+  that crosses a process boundary (an `HIMC` is process-local). The window is the
+  one `GetGUIThreadInfo(foreground thread).hwndFocus` names, **not** the foreground
+  window: a frame and the control focused inside it hand back *different* default
+  IME windows, and only the focused one carries the live state — the frame's stays
+  frozen, so asking it reads a flag nothing consumes and writing to it changes
+  nothing the user can see. Measured on Windows 11 with Notepad; it is what the
+  first Windows pass corrected (`doc/dev/testing.md`). Both calls are further gated
+  on `ImmGetProperty(hkl, IGP_CONVERSION)` being non-zero, i.e. the layout the
+  focused window types under actually has an IME: IMM32 stores an open status even
+  under en-US, where it composes nothing and is dropped at the next layout switch.
+  `ImmIsIME()` cannot make that distinction — on that machine it answers true for
+  the US layout too — and `ImmGetDescription()`/`ImmGetIMEFileName()` are empty even
+  for Microsoft IME, which is a TSF text service with no IMM32 IME file. Sent with
   `SendMessageTimeout(SMTO_NORMAL | SMTO_ABORTIFHUNG, 100 ms)`, **not**
   `SendMessage`: this runs on the main thread inside the `WH_KEYBOARD_LL` callback,
   and a hung target would stall the hook past `LowLevelHooksTimeout` (300 ms) and

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -209,12 +209,37 @@ macOS 15 on this machine). Highlights and the bugs the passes caught:
   the palette input sources (`CharacterPaletteIM`, `50onPaletteIM`, `PressAndHold`)
   report no input mode, so the "first enabled non-Roman mode" selection cannot land
   on one. The tests restore the input source they found.
-- **Windows IME**: `tests/test_win_ime.py` is written and **not yet run** — it needs
-  a machine with Microsoft IME, and it is the outstanding item for the IME API
-  (issue #107). What it has to establish beyond the round trip: that a TSF-only IME
-  answering nothing reads as `None` rather than `False`, and that the
-  `SendMessageTimeout` cap holds — a plain `SendMessage` here would stall the
-  `WH_KEYBOARD_LL` callback past `LowLevelHooksTimeout`.
+- **Windows IME** (2026-08-23, `tests/test_win_ime.py`, Windows 11 26200 with
+  Microsoft IME for Japanese): 11 live tests, and the pass that **caught two real
+  bugs** — the module as first written did not work at all, and its own tests had
+  passed against the broken behavior because they only ever compared the API with
+  itself. What broke that circle was checking against ground truth: driving the IME
+  with the OS's own `VK_IME_ON`/`VK_IME_OFF` and typing `aiueo` into a real control
+  to see whether あいうえお or `aiueo` came out.
+  1. **The foreground window is the wrong window to ask.** A frame and its focused
+     control resolve to different default IME windows. With the IME genuinely on,
+     the focused control's answered `open=1` while the frame's stayed at `0`, so
+     `get_status()` reported off while Japanese was composing, and `set_status(True)`
+     returned True, read back True, and changed nothing visible. Fixed by resolving
+     through `GetGUIThreadInfo(...).hwndFocus`; `test_the_focused_control_is_asked_not_the_frame`
+     is the guard.
+  2. **An open status under a non-IME layout is a phantom.** Under en-US,
+     `set_status(True)` reported success, composed nothing, and the flag was gone
+     after the next layout switch (measured — it is not even latent). Both calls are
+     now gated on `ImmGetProperty(hkl, IGP_CONVERSION)`. Note `ImmIsIME()` is *not*
+     usable for that gate: it answered true for the US layout too.
+  The tests switch the probe thread's layout with `ActivateKeyboardLayout`, so both
+  halves — IME layout and plain layout — run on one machine without touching its
+  settings. Timing held throughout: 0.17 ms per query, far inside `SEND_TIMEOUT_MS`.
+  Three application families were swept by hand, since the frame-vs-focus shape
+  differs between them: **Notepad** (focus is a `RichEditD2DPT` child of the frame —
+  the case that exposed the bug), **Edge/Chromium** (focus *is* the frame; correct
+  either way, and what every Electron app looks like), and a **PuiKit window** — where
+  `set_status(True)` returns False and should: PuiKit associates no input context
+  with a window until a text field wants one (`ImmGetContext` → 0), so there is no
+  IME to open, and the API refuses rather than reporting a success it did not have.
+  Still not covered on this machine: a **TSF-only IME** that answers nothing, which
+  is the only path to `None` (none installed to test against).
 - **macOS element tree and text layer** (2026-08-06, Safari 18 / Chrome on a page
   built to the shape in `doc/dev/ai-integration.md` §2): `children()`,
   `describe()`, `get_ui_tree`, `find_element` by DOM id / label / role / text,
@@ -454,7 +479,11 @@ struck off.
   pressed on JIS hardware. The VKs (0x19 / 0x1C / 0x1D) are the documented ones,
   but no JIS keyboard was available to confirm what the hardware really reports;
   the console's last-key display is the one-line check. Same hardware dependency
-  as the entry below, so pass them together.
+  as the entry below, so pass them together. Still open after the 2026-08-23 IME
+  pass — that machine reports `GetKeyboardType(0) == 4`, so it cannot answer this.
+  What the pass *did* confirm is the other half of those names: injecting
+  `VK_IME_ON`/`VK_IME_OFF` (what `Kana`/`Eisu` send) drives Microsoft IME exactly
+  as `set_ime_status()` does.
 - **JIS layout detection on real JIS hardware** *(passed 2026-08-07; **skipped
   for 2.2.1** — no JIS keyboard available)* — `GetKeyboardType(0) == 7`, one
   line. The tables it selects are pinned against `kbd106.dll` independently, so

--- a/doc/dev/testing.md
+++ b/doc/dev/testing.md
@@ -73,6 +73,14 @@ live on each OS.
   harness records every vk the hook was handed for exactly that reason — 100
   taps is 200 events, and fewer means the burst never arrived to be translated,
   which is a skip rather than a translation failure.
+- **An IME that was just closed costs the *next* test's injection its tail.**
+  The same loss, arriving through a neighbour rather than through the test's
+  own burst. `tests/test_win_ime.py` opens the IME; without settling after it
+  closes one again, the Japanese case of `tests/test_win_send_text.py` received
+  `日本語入力` for `日本語入力のテスト` about one run in five, while that module
+  alone passed 8/8 and the pair passed 6/6 with the IME test deselected — which
+  is how it was attributed. A test that changes IME state owns putting it back
+  *and* pumping afterwards.
 - **A guard must not be able to hide the defect the test exists to catch.**
   These skip only on *detected interference* — focus observed to leave the
   probe, or the pointer observed moving while nothing is injecting — never on

--- a/keyhac/_config.py
+++ b/keyhac/_config.py
@@ -170,9 +170,20 @@ def configure(keymap):
 
     kt[f"{LEADER}-Space"] = toggle_ime
 
-    # A sample of the state going the other way is in the terminal key
-    # table near the bottom: turning the IME off around a send_key()
-    # sequence, and putting it back the way it was.
+    # What *not* to do with these: turn the IME off, send keys, turn it back
+    # on in a finally.  It reads well and it does not work.  set_ime_status()
+    # takes effect at once, while send_key() only queues its events for the
+    # application to pick up later - so the restore wins the race and the
+    # keys compose after all ("git status" arrives as "gいt", measured).
+    # Waiting it out is worse than it looks: a key-triggered action runs on
+    # the main thread inside the keyboard hook, and sleeping there past the
+    # hook timeout is exactly what gets the hook silently unhooked.
+    #
+    # Literal text needs none of this - InputText() and ctx.send_text()
+    # inject the characters themselves, so they land whatever the IME is
+    # doing.  And if keys really must go out with the IME closed, close it
+    # and leave it closed: the Kana / 半角全角 key is how the user puts it
+    # back.
 
     # ==================================================================
     # Clipboard
@@ -438,29 +449,6 @@ def configure(keymap):
 
     kt_terminal = keymap.define_keytable(custom_condition_func=is_terminal)
     kt_terminal[f"{LEADER}-K"] = "Ctrl-K"     # clear, rather than "Down"
-
-    # --- sending keys the IME must not eat -------------------------------
-    # send_key() feeds the IME exactly like real typing, so with a Japanese
-    # IME on this would compose instead of arriving.  send_text() and
-    # InputText() are unaffected - they inject the characters directly - so
-    # this dance is only ever needed when you are sending *keys*.
-    #
-    # `was_on` is tri-state, and falsy is the right reading of None: an IME
-    # we cannot see the state of is one to leave alone, in both directions.
-    def type_git_status():
-        was_on = keymap.get_ime_status()
-        if was_on:
-            keymap.set_ime_status(False)
-        try:
-            with keymap.get_input_context() as ctx:
-                for key in ("G", "I", "T", "Space",
-                            "S", "T", "A", "T", "U", "S"):
-                    ctx.send_key(key)
-        finally:
-            if was_on:
-                keymap.set_ime_status(True)
-
-    kt_terminal[f"{LEADER}-G"] = type_git_status
 
     # ==================================================================
     # More to explore

--- a/keyhac/core/input.py
+++ b/keyhac/core/input.py
@@ -32,6 +32,16 @@ class InputContext:
     afterwards, so ``ctx.send_key("Ctrl-C")`` works even while the modifiers
     of the binding that triggered it are still down.
 
+    Sending is where the batch *ends*, not where it arrives: the events are
+    queued for the application to pick up later.  So anything the action does
+    after the context exits - changing the IME state, activating another
+    window - takes effect while the keys are still in flight, and lands
+    first.  ``keymap.set_ime_status(False)`` around a ``send_key`` batch is
+    the trap this makes: the matching restore wins the race and the keys are
+    composed by the IME after all.  Send literal text with ``send_text()``,
+    which the IME does not intercept, and leave IME changes standing rather
+    than undoing them in the same action.
+
     ``keymap.get_input_context()`` creates one.  It is safe to use from a
     ThreadedAction worker thread.
 

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -1143,7 +1143,14 @@ class Keymap:
             there was none to ask.
 
         Note:
-            UI-thread only.  The two OSes differ in how far "on" reaches:
+            UI-thread only, and it takes effect **at once** - unlike key
+            output, which `InputContext` only queues for the application.
+            Wrapping a `send_key` batch in "off ... back on" therefore does
+            not work: the restore lands before the keys do and they are
+            composed anyway.  Use `InputContext.send_text` for literal text,
+            which the IME does not intercept.
+
+            The two OSes differ in how far "on" reaches:
             macOS selects a Japanese input source even from a US layout,
             while Windows only opens an IME that the focused window is
             already typing under - asking for "on" while a plain layout like

--- a/keyhac/core/keymap.py
+++ b/keyhac/core/keymap.py
@@ -1122,9 +1122,10 @@ class Keymap:
             (Windows) a TSF-only IME does not answer the IMM32 query.
 
         Note:
-            UI-thread only.  On macOS "off" means a plain keyboard layout or
-            an input method's Roman mode is selected, which is close to but
-            not the same thing as Windows' "the IME is closed".
+            UI-thread only.  "Off" is the same answer for two different
+            situations, on both OSes: an IME that is installed and closed,
+            and no IME in the picture at all - a plain keyboard layout on
+            Windows, a plain layout or an input method's Roman mode on macOS.
         """
         if self.ime_provider is None:
             return None
@@ -1142,11 +1143,17 @@ class Keymap:
             there was none to ask.
 
         Note:
-            UI-thread only.  Whether the change also affects other
-            applications is the user's OS setting ("Let me use a different
-            input method for each app window" on Windows, "Automatically
-            switch to a document's input source" on macOS), not something
-            Keyhac decides.
+            UI-thread only.  The two OSes differ in how far "on" reaches:
+            macOS selects a Japanese input source even from a US layout,
+            while Windows only opens an IME that the focused window is
+            already typing under - asking for "on" while a plain layout like
+            en-US is active returns False rather than switching the input
+            language, which is the user's own Win+Space to give.
+
+            Whether a change also affects other applications is the user's
+            OS setting ("Let me use a different input method for each app
+            window" on Windows, "Automatically switch to a document's input
+            source" on macOS), not something Keyhac decides.
         """
         if self.ime_provider is None:
             return False

--- a/keyhac/platform/base.py
+++ b/keyhac/platform/base.py
@@ -237,11 +237,10 @@ class ImeProvider(ABC):
     """IME (input method) on/off state for whatever holds the input focus.
 
     Deliberately window-less.  Windows reaches the state through a window
-    handle (IMM32 input contexts are per thread), so it *could* address a
-    background window; macOS has no such handle - TIS only ever exposes "the
-    current input source".  Naming a window would therefore split the contract
-    between the two OSes, so the portable one is the intersection: whatever has
-    the input focus right now.
+    handle, so it *could* address a background window; macOS has no such
+    handle - TIS only ever exposes "the current input source".  Naming a
+    window would therefore split the contract between the two OSes, so the
+    portable one is the intersection: whatever has the input focus right now.
 
     Whether a change leaks to other applications is the user's OS setting
     ("Let me use a different input method for each app window" on Windows,

--- a/keyhac/platform/win/ime.py
+++ b/keyhac/platform/win/ime.py
@@ -1,4 +1,4 @@
-"""Windows IME control - IMM32 through the foreground window's IME window.
+"""Windows IME control - IMM32 through the focused window's IME window.
 
 The IME open/close state lives in an input context, which by default belongs
 to a thread and is shared by that thread's windows.  A context in another
@@ -19,8 +19,11 @@ Two things make that message send worth care:
   Microsoft IME does.  A TSF-only IME may not answer at all - that is what
   get_status() returning None means, and why it is not folded into False.
 
-STATUS: written to spec; needs a live Windows pass with Microsoft IME (see
-doc/dev/testing.md).
+Live-verified on Windows 11 with Microsoft IME (Japanese), 2026-08-23 - see
+doc/dev/testing.md for what the pass measured, including the two things it
+corrected here: the *focused* window, not the foreground one, is what
+ImmGetDefaultIMEWnd has to be asked about, and an open status read under a
+non-IME layout is a flag nobody consumes.
 """
 
 import ctypes
@@ -54,25 +57,64 @@ if sys.platform == "win32":
     SMTO_NORMAL = 0x0000
     SMTO_ABORTIFHUNG = 0x0002
 
+    #: ImmGetProperty index for the conversion modes a layout can offer.  Zero
+    #: for a layout with no IME behind it - see _layout_has_ime().
+    IGP_CONVERSION = 0x0008
+
+    class GUITHREADINFO(ctypes.Structure):
+        _fields_ = [("cbSize", wintypes.DWORD), ("flags", wintypes.DWORD),
+                    ("hwndActive", wintypes.HWND), ("hwndFocus", wintypes.HWND),
+                    ("hwndCapture", wintypes.HWND),
+                    ("hwndMenuOwner", wintypes.HWND),
+                    ("hwndMoveSize", wintypes.HWND), ("hwndCaret", wintypes.HWND),
+                    ("rcCaret", wintypes.RECT)]
+
     user32.GetForegroundWindow.argtypes = []
     user32.GetForegroundWindow.restype = wintypes.HWND
+    user32.GetWindowThreadProcessId.argtypes = [
+        wintypes.HWND, ctypes.POINTER(wintypes.DWORD)]
+    user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+    user32.GetGUIThreadInfo.argtypes = [wintypes.DWORD,
+                                        ctypes.POINTER(GUITHREADINFO)]
+    user32.GetGUIThreadInfo.restype = wintypes.BOOL
     user32.SendMessageTimeoutW.argtypes = [
         wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM,
         wintypes.UINT, wintypes.UINT, ctypes.POINTER(DWORD_PTR)]
     user32.SendMessageTimeoutW.restype = LRESULT
+    user32.GetKeyboardLayout.argtypes = [wintypes.DWORD]
+    user32.GetKeyboardLayout.restype = wintypes.HKL
     imm32.ImmGetDefaultIMEWnd.argtypes = [wintypes.HWND]
     imm32.ImmGetDefaultIMEWnd.restype = wintypes.HWND
+    imm32.ImmGetProperty.argtypes = [wintypes.HKL, wintypes.DWORD]
+    imm32.ImmGetProperty.restype = wintypes.UINT
 
 
 class WinImeProvider(ImeProvider):
-    """IME on/off of the foreground window's input context."""
+    """IME on/off of the input context the focused window types through."""
 
     def get_status(self) -> bool | None:
-        result = self._ime_control(IMC_GETOPENSTATUS, 0)
+        hwnd = self._input_window()
+        if not hwnd:
+            logger.debug("No foreground window to reach an IME through.")
+            return None
+        if not self._layout_has_ime(hwnd):
+            return False
+        result = self._ime_control(hwnd, IMC_GETOPENSTATUS, 0)
         return None if result is None else bool(result)
 
     def set_status(self, on: bool) -> bool:
-        if self._ime_control(IMC_SETOPENSTATUS, 1 if on else 0) is None:
+        hwnd = self._input_window()
+        if not hwnd:
+            logger.debug("No foreground window to reach an IME through.")
+            return False
+        if not self._layout_has_ime(hwnd):
+            # Off is already true and stays true; on is unreachable.  The
+            # open flag *would* take here - IMM32 stores it on the input
+            # context whatever the layout - but nothing consumes it and the
+            # next layout switch drops it (measured), so reporting success
+            # would be a lie the caller cannot see through.
+            return not on
+        if self._ime_control(hwnd, IMC_SETOPENSTATUS, 1 if on else 0) is None:
             return False
         # Report what was actually reached: an IME may decline the change
         # (no conversion mode available for the current input language).
@@ -80,19 +122,62 @@ class WinImeProvider(ImeProvider):
 
     # ------------------------------------------------------------------
 
-    def _ime_control(self, command: int, value: int) -> int | None:
-        """Send one WM_IME_CONTROL to the foreground window's IME window.
+    @staticmethod
+    def _input_window():
+        """The window whose IME state is the one the user is typing into.
 
-        Returns the message result, or None when there is nothing to ask -
-        no foreground window, no IME for its thread, or the send timed out.
+        Not the foreground window: a frame and the control that actually has
+        the focus can resolve to *different* default IME windows, and only the
+        focused one carries the live state.  Measured on Windows 11 with
+        Notepad, whose RichEditD2DPT edit control answers open=0/1 in step with
+        the IME while its top-level frame stays stuck at 0 - so asking the
+        frame reads a phantom flag that nothing consumes and writing to it
+        changes nothing the user can see.  Falls back to the foreground window
+        when the thread reports no focus (a window can be active with focus
+        nowhere).
         """
         hwnd = user32.GetForegroundWindow()
         if not hwnd:
-            logger.debug("No foreground window to reach an IME through.")
             return None
+        tid = user32.GetWindowThreadProcessId(hwnd, None)
+        info = GUITHREADINFO()
+        info.cbSize = ctypes.sizeof(info)
+        if user32.GetGUIThreadInfo(tid, ctypes.byref(info)) and info.hwndFocus:
+            return info.hwndFocus
+        return hwnd
+
+    @staticmethod
+    def _layout_has_ime(hwnd) -> bool:
+        """Whether the layout the focused window types under has an IME at all.
+
+        Without this the answers are about a flag rather than about the IME:
+        IMM32 keeps an open status on the input context even while a plain
+        layout (en-US) is selected, so set_status(True) there reports success,
+        composes nothing, and is gone at the next layout switch - all three
+        measured on Windows 11 with Microsoft IME installed.
+
+        The obvious test, ImmIsIME(), does not work: on that machine it answers
+        true for the *US* layout too (false only for a layout that is not
+        installed at all), so it separates nothing.  ImmGetDescription() and
+        ImmGetIMEFileName() are no help either - both are empty even for
+        Microsoft IME, which is a TSF text service with no IMM32 IME file
+        behind it.  What does separate them is the set of conversion modes the
+        layout offers: 0 for en-US, IME_CMODE_NATIVE|KATAKANA|FULLSHAPE (0xb)
+        for Microsoft IME.
+        """
+        tid = user32.GetWindowThreadProcessId(hwnd, None)
+        hkl = user32.GetKeyboardLayout(tid)
+        return bool(imm32.ImmGetProperty(hkl, IGP_CONVERSION))
+
+    def _ime_control(self, hwnd, command: int, value: int) -> int | None:
+        """Send one WM_IME_CONTROL to the given window's IME window.
+
+        Returns the message result, or None when there is nothing to ask -
+        no IME window for the target's thread, or the send timed out.
+        """
         ime_hwnd = imm32.ImmGetDefaultIMEWnd(hwnd)
         if not ime_hwnd:
-            logger.debug("The foreground window's thread has no IME window.")
+            logger.debug("The focused window's thread has no IME window.")
             return None
 
         result = DWORD_PTR()

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -120,19 +120,26 @@ def test_the_ime_samples_run(shipped):
     assert shipped.get_ime_status() is False
 
 
-def test_the_ime_sample_restores_the_state_it_found(shipped):
-    from keyhac.platform.fake import FakeImeProvider
+def test_the_template_types_text_without_going_near_the_ime(shipped):
+    """Literal text goes out as InputText, never as a send_key() batch.
 
-    shipped.ime_provider = FakeImeProvider(status=True)
-    type_git_status = shipped_action(shipped, "type_git_status")
+    The distinction is not cosmetic: a batch is only *queued* for the
+    application, so the "turn the IME off, send the keys, turn it back on"
+    shape a config reaches for cannot work - the restore lands before the keys
+    and "git status" arrives as "gいt" (doc/configuration.md). InputText
+    injects the characters themselves, which the IME does not intercept, so
+    there is nothing to turn off.
+    """
+    from keyhac.core.action import InputText
 
-    type_git_status()
-    assert shipped.get_ime_status() is True, "the IME was left off"
-    assert shipped._hook.sent, "no keys reached the hook"
+    typed = [action for table in shipped._all_keytables
+             for action in table.table.values()
+             if isinstance(action, InputText)]
+    assert typed, "the template no longer shows InputText"
 
 
-def test_the_ime_samples_leave_an_unreadable_ime_alone(shipped, caplog):
-    """None means "could not tell"; neither sample may act on it."""
+def test_the_ime_sample_leaves_an_unreadable_ime_alone(shipped, caplog):
+    """None means "could not tell"; the toggle must say so rather than act."""
     from keyhac.platform.fake import FakeImeProvider
 
     shipped.ime_provider = FakeImeProvider(status=None)
@@ -140,6 +147,4 @@ def test_the_ime_samples_leave_an_unreadable_ime_alone(shipped, caplog):
     with caplog.at_level("WARNING"):
         shipped_action(shipped, "toggle_ime")()
     assert "No IME to toggle" in caplog.text
-
-    shipped_action(shipped, "type_git_status")()
     assert shipped.get_ime_status() is None

--- a/tests/test_win_ime.py
+++ b/tests/test_win_ime.py
@@ -130,17 +130,32 @@ class ImeProbe:
                 user32.DispatchMessageW(msg)
             time.sleep(0.005)
 
+    def require_focus(self) -> None:
+        """A busy desktop can take the probe's focus mid-run, and the injection
+        then lands in somebody else's window.  That is a skip, not a failure -
+        the house rule for the live input tests (doc/dev/testing.md)."""
+        if user32.GetFocus() != self.edit:
+            pytest.skip("keyboard focus left the probe mid-test")
+
+    def clear(self) -> None:
+        user32.SendMessageW(self.edit, WM_SETTEXT, 0, ctypes.c_wchar_p(""))
+
+    def read(self) -> str:
+        buffer = ctypes.create_unicode_buffer(64)
+        user32.SendMessageW(self.edit, WM_GETTEXT, 64, buffer)
+        return buffer.value
+
     def type_and_read(self, vks=(VK_A,)) -> str:
         """Type through the IME, commit, and return what the control kept."""
+        self.require_focus()
         user32.SendMessageW(self.edit, WM_SETTEXT, 0, ctypes.c_wchar_p(""))
         events = []
         for vk in (*vks, VK_RETURN):
             events += [(vk, True), (vk, False)]
         WinInputHook().send(events)
         self.pump(0.6)
-        buffer = ctypes.create_unicode_buffer(64)
-        user32.SendMessageW(self.edit, WM_GETTEXT, 64, buffer)
-        return buffer.value.strip()
+        self.require_focus()
+        return self.read().strip()
 
     def destroy(self) -> None:
         user32.DestroyWindow(self.hwnd)
@@ -175,7 +190,13 @@ def ime_layout(probe):
     user32.ActivateKeyboardLayout(with_ime[0], 0)
     probe.pump(0.3)
     yield probe
+    # Close it *and* let it settle.  An IME that was just closed still costs
+    # the next injection its tail: leaving without the pump made the Japanese
+    # case of tests/test_win_send_text.py drop characters about one run in
+    # five, which is the "injected input is occasionally lost" hazard in
+    # doc/dev/testing.md arriving through a neighbour.
     WinImeProvider().set_status(False)
+    probe.pump(0.3)
 
 
 @pytest.fixture
@@ -232,6 +253,28 @@ class TestUnderAnImeLayout:
         assert plain == "a"
         assert composed and not composed.isascii(), (
             f"IME on produced {composed!r}, expected a composed character")
+
+
+    def test_send_text_goes_through_an_open_ime_untouched(self, ime_layout,
+                                                          provider):
+        """Why the config template types literal text with send_text().
+
+        It injects the characters themselves rather than feeding keys to the
+        IME, so it needs no IME dance - and the dance a config would reach for
+        instead ("off, send, back on") cannot work: the state change is
+        immediate while the keys are only queued for the application.
+        """
+        assert provider.set_status(True) is True
+        ime_layout.pump(0.3)          # let the IME finish opening
+        ime_layout.require_focus()
+        ime_layout.clear()
+        WinInputHook().send_text("git status")
+        ime_layout.pump(0.8)
+        ime_layout.require_focus()
+        text = ime_layout.read()
+        provider.set_status(False)    # this test is the one that opened it
+        ime_layout.pump(0.3)
+        assert text == "git status"
 
 
 class TestUnderALayoutWithNoIme:

--- a/tests/test_win_ime.py
+++ b/tests/test_win_ime.py
@@ -1,64 +1,272 @@
-"""Windows IME provider - live against the real IMM32 state.
+"""Windows IME provider - live, against a probe window this process owns.
 
-Needs an IME installed for the current input language (Microsoft IME); the
-whole module skips otherwise, since a machine with no IME can only ever answer
-None.  The state read and written is the foreground window's - i.e. whatever
-console pytest is running in - and the fixture puts it back afterwards.
+The probe is an EDIT control in a frame of its own, which is what makes the
+interesting case testable: the frame and the control resolve to *different*
+default IME windows, and only the focused control's carries the live state.
+Asking the frame - what this module was written against before the first
+Windows pass - reads a flag nothing consumes (doc/dev/testing.md).
 
-STATUS: written to spec; run this on the Windows pass (doc/dev/testing.md).
+The layout is switched on this thread with ActivateKeyboardLayout, so both
+halves of the contract are reachable without touching the machine's settings:
+an IME layout (Microsoft IME) for the on/off round trip, and a plain one
+(en-US) for "there is no IME to turn on".  Each half skips if that layout is
+not installed.  Briefly takes keyboard focus; skips if the environment refuses
+it, as tests/test_win_send_text.py does.
 """
 
+import ctypes
 import sys
+import time
 
 import pytest
 
 if sys.platform != "win32":
     pytest.skip("Windows-only platform layer", allow_module_level=True)
 
+from ctypes import wintypes  # noqa: E402
+
+from keyhac.platform.win.hook import WinInputHook  # noqa: E402
 from keyhac.platform.win.ime import WinImeProvider  # noqa: E402
+from keyhac.platform.win.window import WinWindow  # noqa: E402
+
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+imm32 = ctypes.WinDLL("imm32", use_last_error=True)
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+WNDPROC = ctypes.WINFUNCTYPE(
+    ctypes.c_ssize_t, wintypes.HWND, wintypes.UINT,
+    wintypes.WPARAM, wintypes.LPARAM)
+user32.DefWindowProcW.argtypes = [
+    wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM]
+user32.DefWindowProcW.restype = ctypes.c_ssize_t
+user32.CreateWindowExW.argtypes = [
+    wintypes.DWORD, wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD,
+    ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+    wintypes.HWND, wintypes.HMENU, wintypes.HINSTANCE, wintypes.LPVOID]
+user32.CreateWindowExW.restype = wintypes.HWND
+user32.DestroyWindow.argtypes = [wintypes.HWND]
+user32.ShowWindow.argtypes = [wintypes.HWND, ctypes.c_int]
+user32.SetFocus.argtypes = [wintypes.HWND]
+user32.SetFocus.restype = wintypes.HWND
+user32.GetFocus.argtypes = []
+user32.GetFocus.restype = wintypes.HWND
+user32.SendMessageW.argtypes = [
+    wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPVOID]
+user32.SendMessageW.restype = ctypes.c_ssize_t
+user32.PeekMessageW.argtypes = [
+    ctypes.c_void_p, wintypes.HWND, wintypes.UINT, wintypes.UINT, wintypes.UINT]
+user32.TranslateMessage.argtypes = [ctypes.c_void_p]
+user32.DispatchMessageW.argtypes = [ctypes.c_void_p]
+user32.GetKeyboardLayout.argtypes = [wintypes.DWORD]
+user32.GetKeyboardLayout.restype = wintypes.HKL
+user32.GetKeyboardLayoutList.argtypes = [ctypes.c_int, ctypes.POINTER(wintypes.HKL)]
+user32.ActivateKeyboardLayout.argtypes = [wintypes.HKL, wintypes.UINT]
+user32.ActivateKeyboardLayout.restype = wintypes.HKL
+imm32.ImmGetProperty.argtypes = [wintypes.HKL, wintypes.DWORD]
+imm32.ImmGetProperty.restype = wintypes.UINT
+kernel32.GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
+kernel32.GetModuleHandleW.restype = wintypes.HMODULE
+
+IGP_CONVERSION = 0x0008
+WM_SETTEXT, WM_GETTEXT = 0x000C, 0x000D
+VK_A, VK_RETURN = 0x41, 0x0D
+
+
+class WNDCLASSW(ctypes.Structure):
+    _fields_ = [
+        ("style", wintypes.UINT), ("lpfnWndProc", WNDPROC),
+        ("cbClsExtra", ctypes.c_int), ("cbWndExtra", ctypes.c_int),
+        ("hInstance", wintypes.HINSTANCE), ("hIcon", ctypes.c_void_p),
+        ("hCursor", ctypes.c_void_p), ("hbrBackground", ctypes.c_void_p),
+        ("lpszMenuName", wintypes.LPCWSTR), ("lpszClassName", wintypes.LPCWSTR),
+    ]
+
+
+user32.RegisterClassW.argtypes = [ctypes.POINTER(WNDCLASSW)]
+
+
+def _layouts_with_and_without_ime():
+    """The installed layouts, split by whether an IME sits behind them."""
+    count = user32.GetKeyboardLayoutList(0, None)
+    layouts = (wintypes.HKL * count)()
+    user32.GetKeyboardLayoutList(count, layouts)
+    with_ime, without = [], []
+    for hkl in layouts:
+        bucket = with_ime if imm32.ImmGetProperty(hkl, IGP_CONVERSION) else without
+        bucket.append(hkl)
+    return with_ime, without
+
+
+class ImeProbe:
+    """A frame with one EDIT child - a focused control distinct from its frame."""
+
+    def __init__(self):
+        self._proc = WNDPROC(user32.DefWindowProcW)  # must outlive the window
+        wc = WNDCLASSW()
+        wc.lpfnWndProc = self._proc
+        wc.hInstance = kernel32.GetModuleHandleW(None)
+        wc.lpszClassName = "KeyhacImeProbe"
+        user32.RegisterClassW(ctypes.byref(wc))  # repeat registration: benign
+        WS_OVERLAPPEDWINDOW, WS_CHILD, WS_VISIBLE = 0x00CF0000, 0x40000000, 0x10000000
+        ES_MULTILINE = 0x0004
+        self.hwnd = user32.CreateWindowExW(
+            0, "KeyhacImeProbe", "IME probe", WS_OVERLAPPEDWINDOW,
+            60, 60, 320, 140, None, None, wc.hInstance, None)
+        if not self.hwnd:
+            raise OSError(f"CreateWindowExW: {ctypes.get_last_error()}")
+        self.edit = user32.CreateWindowExW(
+            0, "EDIT", "", WS_CHILD | WS_VISIBLE | ES_MULTILINE,
+            0, 0, 300, 100, self.hwnd, 1, wc.hInstance, None)
+        if not self.edit:
+            raise OSError(f"CreateWindowExW(EDIT): {ctypes.get_last_error()}")
+        user32.ShowWindow(self.hwnd, 5)  # SW_SHOW
+
+    def pump(self, seconds: float) -> None:
+        end = time.monotonic() + seconds
+        msg = ctypes.create_string_buffer(48)
+        while time.monotonic() < end:
+            while user32.PeekMessageW(msg, None, 0, 0, 1):  # PM_REMOVE
+                user32.TranslateMessage(msg)
+                user32.DispatchMessageW(msg)
+            time.sleep(0.005)
+
+    def type_and_read(self, vks=(VK_A,)) -> str:
+        """Type through the IME, commit, and return what the control kept."""
+        user32.SendMessageW(self.edit, WM_SETTEXT, 0, ctypes.c_wchar_p(""))
+        events = []
+        for vk in (*vks, VK_RETURN):
+            events += [(vk, True), (vk, False)]
+        WinInputHook().send(events)
+        self.pump(0.6)
+        buffer = ctypes.create_unicode_buffer(64)
+        user32.SendMessageW(self.edit, WM_GETTEXT, 64, buffer)
+        return buffer.value.strip()
+
+    def destroy(self) -> None:
+        user32.DestroyWindow(self.hwnd)
 
 
 @pytest.fixture(scope="module")
+def probe():
+    probe = ImeProbe()
+    WinWindow(probe.hwnd).activate()
+    user32.SetFocus(probe.edit)
+    probe.pump(0.2)
+    if user32.GetFocus() != probe.edit:
+        probe.destroy()
+        pytest.skip("environment refused keyboard focus")
+    saved_layout = user32.GetKeyboardLayout(0)
+    yield probe
+    user32.ActivateKeyboardLayout(saved_layout, 0)
+    probe.destroy()
+
+
+@pytest.fixture
 def provider():
-    provider = WinImeProvider()
-    saved = provider.get_status()
-    if saved is None:
-        pytest.skip("no IME answers IMM32 for the foreground window")
-    yield provider
-    provider.set_status(saved)
+    return WinImeProvider()
 
 
-def test_status_is_a_bool_when_an_ime_answers(provider):
-    assert provider.get_status() in (True, False)
+@pytest.fixture
+def ime_layout(probe):
+    """The probe typing under a layout that has an IME (Microsoft IME)."""
+    with_ime, _ = _layouts_with_and_without_ime()
+    if not with_ime:
+        pytest.skip("no IME layout installed (Microsoft IME needed)")
+    user32.ActivateKeyboardLayout(with_ime[0], 0)
+    probe.pump(0.3)
+    yield probe
+    WinImeProvider().set_status(False)
 
 
-def test_turning_on_and_off_round_trips(provider):
-    assert provider.set_status(True) is True
-    assert provider.get_status() is True
-    assert provider.set_status(False) is True
-    assert provider.get_status() is False
+@pytest.fixture
+def plain_layout(probe):
+    """The probe typing under a layout with no IME behind it (en-US)."""
+    _, without = _layouts_with_and_without_ime()
+    if not without:
+        pytest.skip("every installed layout has an IME")
+    user32.ActivateKeyboardLayout(without[0], 0)
+    probe.pump(0.3)
+    yield probe
 
 
-def test_setting_the_state_it_is_already_in_succeeds(provider):
-    provider.set_status(False)
-    assert provider.set_status(False) is True
-    assert provider.get_status() is False
+class TestWhatGetsAsked:
+
+    def test_the_focused_control_is_asked_not_the_frame(self, probe, provider):
+        """The regression guard for the bug the first Windows pass found.
+
+        A frame and its focused child hand back different default IME windows,
+        and the frame's answers are frozen - so resolving the target through
+        GetForegroundWindow() alone reads and writes a phantom state.
+        """
+        assert provider._input_window() == probe.edit != probe.hwnd
 
 
-def test_the_send_is_capped_well_under_the_hook_timeout():
-    """The cap is load-bearing: this runs inside the WH_KEYBOARD_LL callback,
-    and exceeding LowLevelHooksTimeout (300 ms) gets the hook silently
-    unhooked."""
-    from keyhac.platform.win import ime
-    assert ime.SEND_TIMEOUT_MS <= 150
+class TestUnderAnImeLayout:
+
+    def test_status_is_a_bool_when_an_ime_answers(self, ime_layout, provider):
+        assert provider.get_status() in (True, False)
+
+    def test_turning_on_and_off_round_trips(self, ime_layout, provider):
+        assert provider.set_status(True) is True
+        assert provider.get_status() is True
+        assert provider.set_status(False) is True
+        assert provider.get_status() is False
+
+    def test_setting_the_state_it_is_already_in_succeeds(self, ime_layout, provider):
+        provider.set_status(False)
+        assert provider.set_status(False) is True
+        assert provider.get_status() is False
+
+    def test_turning_it_on_is_what_the_application_then_composes(
+            self, ime_layout, provider):
+        """The end-to-end check: the state has to reach the keystrokes.
+
+        Typing 'a' with the IME on yields a kana character, off yields 'a'.
+        What is composed depends on the IME's own mode, so this asserts only
+        that the result stopped being ASCII - not that it is any one kana.
+        """
+        assert provider.set_status(True) is True
+        composed = ime_layout.type_and_read()
+        assert provider.set_status(False) is True
+        plain = ime_layout.type_and_read()
+        assert plain == "a"
+        assert composed and not composed.isascii(), (
+            f"IME on produced {composed!r}, expected a composed character")
 
 
-def test_a_query_returns_promptly(provider):
-    """A responsive IME answers far inside the cap; this is the regression
-    guard for accidentally reintroducing a blocking SendMessage."""
-    import time
-    start = time.perf_counter()
-    for _ in range(10):
-        provider.get_status()
-    elapsed_ms = (time.perf_counter() - start) * 1000
-    assert elapsed_ms < 10 * 50
+class TestUnderALayoutWithNoIme:
+    """An open status set here takes, composes nothing, and is dropped at the
+    next layout switch - so the honest answers are off and refusal."""
+
+    def test_it_reads_off(self, plain_layout, provider):
+        assert provider.get_status() is False
+
+    def test_turning_it_on_fails(self, plain_layout, provider):
+        assert provider.set_status(True) is False
+        assert provider.get_status() is False
+
+    def test_turning_it_off_succeeds(self, plain_layout, provider):
+        assert provider.set_status(False) is True
+
+    def test_nothing_is_composed(self, plain_layout, provider):
+        provider.set_status(True)
+        assert plain_layout.type_and_read() == "a"
+
+
+class TestTheSendItself:
+
+    def test_the_send_is_capped_well_under_the_hook_timeout(self):
+        """The cap is load-bearing: this runs inside the WH_KEYBOARD_LL
+        callback, and exceeding LowLevelHooksTimeout (300 ms) gets the hook
+        silently unhooked."""
+        from keyhac.platform.win import ime
+        assert ime.SEND_TIMEOUT_MS <= 150
+
+    def test_a_query_returns_promptly(self, probe, provider):
+        """A responsive IME answers far inside the cap; this is the regression
+        guard for accidentally reintroducing a blocking SendMessage."""
+        start = time.perf_counter()
+        for _ in range(10):
+            provider.get_status()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert elapsed_ms < 10 * 50


### PR DESCRIPTION
The two commits that were still local when #109 was merged — `origin/ime-status-api` was two behind the working branch, so #109 landed only the API and the `start_action` fix. Rebased onto main, no conflicts.

- **The Windows IME pass corrects what the API was asking** — `tests/test_win_ime.py` had been written to spec and never run. Running it against ground truth found two bugs. The foreground window is the wrong window to ask: a frame and the control focused inside it resolve to different default IME windows, and only the focused one carries the live state, so `get_status()` reported off while Japanese was composing. And an open status under a layout with no IME is a phantom — IMM32 stores it whatever the layout, so under en-US `set_status(True)` reported success and composed nothing. Both calls are now gated on `ImmGetProperty(hkl, IGP_CONVERSION)`; `ImmIsIME()` cannot make that call, answering true for the US layout too. The tests are rebuilt around a probe window this process owns, switching the thread's layout with `ActivateKeyboardLayout` so both halves of the contract run on one machine.

- **The IME sample was racing its own keystrokes** — reported from a live config: with the IME on, the template's `type_git_status()` typed straight through it. `set_ime_status()` takes effect at once while `send_key()` only queues its events, so the restore in the `finally` landed while the keys were still in flight. Waiting is not the fix hiding behind that: a key-triggered action runs inside the `WH_KEYBOARD_LL` callback, and the delay that makes the sample work is the delay that gets the hook silently unhooked. The sample goes; `send_text()` never needed the dance. `InputContext` and `set_ime_status()` now document that the batch is queued rather than delivered, which is what made the broken shape writable in the first place.

601 passed on the rebased tree — the seven that `tests/test_win_ime.py` gains back over the version #109 shipped — and `make api-reference-check` is in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)